### PR TITLE
chore(ci): remove redundant build step from production workflow

### DIFF
--- a/.github/workflows/app-deploy-main.yml
+++ b/.github/workflows/app-deploy-main.yml
@@ -63,9 +63,6 @@ jobs:
       - name: Run tests
         run: pnpm test
       
-      - name: Build game client and dependencies
-        run: pnpm turbo run build
-      
       - name: Deploy to Vercel
         id: deploy
         uses: amondnet/vercel-action@v25


### PR DESCRIPTION
### **User description**
## Description
Align production deploy with the PR workflow by removing the redundant `pnpm turbo run build` step from `app-deploy-main`.

- **Problem:** After recent changes, `pnpm turbo run build` in the main workflow was building all apps in the monorepo instead of only game-client, and the built output was not used for the deployment.
- **Fix:** Rely on Vercel to build from the repo (as in app-deploy-pr). CI still runs typecheck, lint, and tests before deploy; E2E and Lighthouse run after deploy. No build step in CI for app-deploy-main.

This matches the PR flow (tests → deploy; Vercel builds) and avoids unnecessary turbo build of all apps on every push to main.

---

## Linked Issues

Closes #<issue-number-if-you-have-one>

---

## Type

- [ ] `feat` - New feature
- [ ] `chore` - Infrastructure, setup tasks, non-feature work
- [x] `fix` - Bug fix
- [ ] `docs` - Documentation changes
- [ ] `test` - Testing-related changes

---

## Scope

- [ ] `game-client` - Game client application
- [ ] `backoffice-client` - Backoffice client application
- [ ] `ui` - UI package
- [ ] `storybook` - Storybook tool
- [x] `e2e` - E2E testing
- [x] `global` - Shared packages or general repository tasks

---

## Screenshots (Optional)



---

## Preview Links (Optional)



---

## Testing Notes

- [ ] Tests pass locally
- [ ] Linting passes

- Push to a branch and open a PR to confirm app-deploy-pr still runs as before.
- After merge, confirm app-deploy-main runs without the build step and that the game-client production deploy and E2E/Lighthouse steps succeed.

---

## Documentation Changes (if applicable)

- [ ] Added or updated documentation files
- [ ] Updated cross-references in other docs (if files were renamed/moved)
- [ ] Verified all internal links still work
- [x] N/A - No documentation changes


___

### **PR Type**
Bug fix


___

### **Description**
- Remove redundant build step from production deployment workflow

- Rely on Vercel to handle building from repository

- Align production deploy with PR workflow pattern

- Reduce unnecessary turbo build execution on main pushes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Pipeline"] --> B["Typecheck & Lint"]
  B --> C["Run Tests"]
  C --> D["Deploy to Vercel"]
  D --> E["Vercel Builds App"]
  E --> F["E2E & Lighthouse"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app-deploy-main.yml</strong><dd><code>Remove build step, rely on Vercel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/app-deploy-main.yml

<ul><li>Removed the <code>pnpm turbo run build</code> step from the production deployment <br>workflow<br> <li> Simplified CI pipeline to rely on Vercel for building instead of <br>building in CI<br> <li> Maintains typecheck, lint, and test steps before deployment<br> <li> Aligns production workflow with PR deployment pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/kartuli-app/kartuli/pull/46/files#diff-cdf98c53fd50de9c9ca3d84cf5b82dbebd222f11279cdc401a4d882cbce32c5a">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

