### PR TITLE
chore(ci): update base branch for affected package detection in staging orchestrator

### DIFF
--- a/.github/workflows/orchestrator-staging.yml
+++ b/.github/workflows/orchestrator-staging.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Detect affected packages (build)
         id: affected
+        env:
+          TURBO_SCM_BASE: origin/main
         run: |
           pnpm exec turbo run build --dry=json --affected > turbo-dry.json 2>/dev/null || true
           AFFECTED_BUILD=$(jq -r '.tasks[]? | .package' turbo-dry.json 2>/dev/null | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
@@ -55,4 +57,4 @@ jobs:
             echo "$BUILD_PKGS" | jq -r '.[]' 2>/dev/null | sed 's/^/- /' >> "$GITHUB_STEP_SUMMARY"
           fi
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "*Using \`turbo run build --dry=json --affected\` (base: default branch)*" >> "$GITHUB_STEP_SUMMARY"
+          echo "*Using \`turbo run build --dry=json --affected\` (base: origin/main)*" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### **User description**
## What we're fixing

The staging orchestrator was reporting **all packages** as affected on every PR, while locally `pnpm run affected:pr` correctly reported 0 affected for workflow-only changes.

**Cause:** In CI, Turbo’s `--affected` base ref was not set explicitly. Turbo’s default base can differ in Actions, so the “changed files” comparison was wrong and everything was considered affected.

**Fix:** Set `TURBO_SCM_BASE=origin/main` in the detect-affected job so Turbo compares the PR to `main` (same as the intended behavior of the root script `affected:pr`).

## How to verify

This PR only touches `.github/workflows/orchestrator-staging.yml`. After the Orchestrator (Staging) run completes, the job summary should show **“No packages would run \`build\` for this change.”** (0 affected). If it still lists packages, the fix needs more adjustment.


___

### **PR Type**
Bug fix


___

### **Description**
- Set TURBO_SCM_BASE environment variable to origin/main

- Ensures Turbo compares PR against correct base branch

- Fixes false positive affected package detection in CI

- Updates job summary to reflect actual base reference


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Staging Orchestrator"] -->|Previously: default base| B["Turbo detects all packages affected"]
  A -->|Now: origin/main base| C["Turbo correctly detects affected packages"]
  D["TURBO_SCM_BASE env var"] -->|Added to detect-affected job| A
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>orchestrator-staging.yml</strong><dd><code>Set explicit base branch for Turbo affected detection</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/orchestrator-staging.yml

<ul><li>Added <code>TURBO_SCM_BASE: origin/main</code> environment variable to <br>detect-affected job<br> <li> Ensures Turbo uses consistent base branch reference for affected <br>package detection<br> <li> Updated job summary message to reflect the explicit base reference <br>(origin/main)<br> <li> Fixes issue where all packages were incorrectly reported as affected <br>in CI</ul>


</details>


  </td>
  <td><a href="https://github.com/kartuli-app/kartuli/pull/47/files#diff-6b1e26514bbd6da9d33ddf7186b4b10078fa90f9b4bc14154d1d0b9e9d0a0fed">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

