### PR TITLE
fix(DeploymentDebugPanel): remove hydration errors

### DIFF
--- a/packages/ui/src/components/DeploymentDebugPanel.test.tsx
+++ b/packages/ui/src/components/DeploymentDebugPanel.test.tsx
@@ -115,6 +115,9 @@ describe('DeploymentDebugPanel', () => {
     expect(screen.getByText(/Build:/)).toBeInTheDocument();
 
     const buildTimeContainer = screen.getByText(/Build:/).parentElement;
-    expect(buildTimeContainer?.textContent).toMatch(/\d+\/\d+\/\d+, \d+:\d+:\d+ [AP]M|unknown/);
+    // Anchored regex with fixed quantifiers to avoid ReDoS; matches full line (Build: <date> or Build: unknown)
+    expect(buildTimeContainer?.textContent?.trim()).toMatch(
+      /^Build: (\d{1,2}\/\d{1,2}\/\d{4}, \d{1,2}:\d{2}:\d{2} [AP]M|unknown)$/,
+    );
   });
 });

--- a/packages/ui/src/components/DeploymentDebugPanel.tsx
+++ b/packages/ui/src/components/DeploymentDebugPanel.tsx
@@ -42,10 +42,23 @@ export function DeploymentDebugPanel({
 }: DeploymentDebugPanelProps) {
   // === BUILD TIME (static, set at build) ===
   // Use only NEXT_PUBLIC_BUILD_TIME so server and client render the same (no hydration mismatch).
-  const buildTimeRaw = process.env.NEXT_PUBLIC_BUILD_TIME ?? 'unknown';
-  const buildDate = buildTimeRaw !== 'unknown' ? new Date(buildTimeRaw) : null;
-  const buildTimeFormatted =
-    buildDate && !Number.isNaN(buildDate.getTime()) ? buildDate.toLocaleString() : 'unknown';
+  const buildTimeRaw = process.env.NEXT_PUBLIC_BUILD_TIME;
+  let buildTimeFormatted = 'unknown';
+
+  if (buildTimeRaw) {
+    const date = new Date(buildTimeRaw);
+    if (!Number.isNaN(date.getTime())) {
+      buildTimeFormatted = date.toLocaleString('en-US', {
+        month: 'numeric',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+        second: 'numeric',
+        hour12: true,
+      });
+    }
+  }
 
   // === APPLICATION INFORMATION ===
   // Now using required props directly - no fallback to unreliable process.env


### PR DESCRIPTION
### **User description**
## Description
Fixes hydration mismatches in `DeploymentDebugPanel` that caused production e2e to fail (console errors) after the Next.js 16 upgrade.

- **Build time:** Use only `NEXT_PUBLIC_BUILD_TIME` (or `"unknown"` when unset). Removed `useState`/`useEffect` and client-time fallback so server and client render the same.
- **Repo:** Removed the Repo block and all use of `VERCEL_GIT_REPO_OWNER` / `VERCEL_GIT_REPO_SLUG` (server-only, caused mismatch).
- **PR:** Removed the PR block and `VERCEL_GIT_PULL_REQUEST_NUMBER` (server-only, same issue).
- **Tests:** Updated build time assertion to allow `"unknown"` instead of `"loading..."`.

---

## Linked Issues
Closes #

---

## Type
- [x] `fix` - Bug fix

---

## Scope
- [x] `game-client`
- [x] `backoffice-client`
- [x] `ui`
- [x] `global`

---

## Screenshots (Optional)
N/A

---

## Preview Links (Optional)
N/A

---

## Testing Notes
- [x] Tests pass locally
- [x] Linting passes

`pnpm run test` passes (13 tests). Recommend running e2e against Vercel deployment to confirm no hydration console errors.

---

## Documentation Changes (if applicable)
- [x] N/A - No documentation changes


___

### **PR Type**
Bug fix


___

### **Description**
- Remove hydration mismatches by eliminating client-side state and server-only variables

- Simplify build time handling to use only `NEXT_PUBLIC_BUILD_TIME` environment variable

- Remove unused Repo and PR information blocks that relied on server-only variables

- Update test assertions to expect `"unknown"` instead of `"loading..."` for build time


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DeploymentDebugPanel Component"] -->|Remove| B["useState/useEffect hooks"]
  A -->|Remove| C["Server-only env variables"]
  A -->|Simplify| D["Build time handling"]
  D -->|Use only| E["NEXT_PUBLIC_BUILD_TIME"]
  C -->|Removed| F["Repo block"]
  C -->|Removed| G["PR block"]
  H["Test file"] -->|Update| I["Build time regex pattern"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DeploymentDebugPanel.tsx</strong><dd><code>Eliminate hydration mismatches and server-only variables</code>&nbsp; </dd></summary>
<hr>

packages/ui/src/components/DeploymentDebugPanel.tsx

<ul><li>Removed <code>useState</code> and <code>useEffect</code> imports and client-side time state <br>management<br> <li> Simplified build time logic to use only <code>NEXT_PUBLIC_BUILD_TIME</code> <br>environment variable with <code>"unknown"</code> fallback<br> <li> Removed server-only environment variable access <br>(<code>VERCEL_GIT_REPO_OWNER</code>, <code>VERCEL_GIT_REPO_SLUG</code>, <br><code>VERCEL_GIT_PULL_REQUEST_NUMBER</code>, <code>VERCEL_GIT_COMMIT_MESSAGE</code>)<br> <li> Removed Repo and PR information display blocks from the component UI<br> <li> Removed server-side only variables comment section<br> <li> Simplified build information display to show formatted date or <br><code>"unknown"</code> without loading state</ul>


</details>


  </td>
  <td><a href="https://github.com/kartuli-app/kartuli/pull/52/files#diff-26d13fd819eb29ff68f7ed8a2e52487f75115865a5501a0a699d09e9e9d6938f">+7/-58</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DeploymentDebugPanel.test.tsx</strong><dd><code>Update build time test assertions for static values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/components/DeploymentDebugPanel.test.tsx

<ul><li>Updated build time test comment to clarify static behavior with <br><code>NEXT_PUBLIC_BUILD_TIME</code> or <code>"unknown"</code><br> <li> Removed assertion for <code>"loading..."</code> state from regex pattern<br> <li> Updated regex to match either formatted date or <code>"unknown"</code> string<br> <li> Removed outdated comment about client-time fallback</ul>


</details>


  </td>
  <td><a href="https://github.com/kartuli-app/kartuli/pull/52/files#diff-33a276cf042bc015bd24f5008175ff96df7ba2bbb2d679706a691491f29408f9">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

