### PR TITLE
feat(game-client): add settings page and shared locale navigation helpers

### DIFF
--- a/apps/game-client/src/app/[locale]/settings/page.tsx
+++ b/apps/game-client/src/app/[locale]/settings/page.tsx
@@ -1,4 +1,4 @@
-import { generateStaticParamsForSupportedLocales } from '@game-client/i18n/';
+import { generateStaticParamsForSupportedLocales } from '@game-client/i18n';
 
 export function generateStaticParams() {
   return generateStaticParamsForSupportedLocales();

--- a/apps/game-client/src/app/[locale]/settings/page.tsx
+++ b/apps/game-client/src/app/[locale]/settings/page.tsx
@@ -1,0 +1,7 @@
+import { generateStaticParamsForSupportedLocales } from '@game-client/i18n/';
+
+export function generateStaticParams() {
+  return generateStaticParamsForSupportedLocales();
+}
+
+export { SettingsPageServer as default } from '@game-client/ui/screens/settings/settings-page-server';

--- a/apps/game-client/src/i18n/index.ts
+++ b/apps/game-client/src/i18n/index.ts
@@ -7,3 +7,4 @@ export {
   supportedLocales,
 } from './i18n-constants';
 export { I18nProvider } from './i18n-provider';
+export { getCurrentSupportedLocale, getLocalizedPathnameForLocale } from './locale-utils';

--- a/apps/game-client/src/i18n/locale-utils.test.ts
+++ b/apps/game-client/src/i18n/locale-utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { getCurrentSupportedLocale, getLocalizedPathnameForLocale } from './locale-utils';
+
+describe('getCurrentSupportedLocale', () => {
+  it('returns the exact supported locale when resolved language matches', () => {
+    expect(getCurrentSupportedLocale('en')).toBe('en');
+    expect(getCurrentSupportedLocale('ru')).toBe('ru');
+  });
+
+  it('normalizes region-specific locales to the supported base locale', () => {
+    expect(getCurrentSupportedLocale('en-US')).toBe('en');
+    expect(getCurrentSupportedLocale('ru-RU')).toBe('ru');
+  });
+
+  it('falls back to the provided locale when resolved language is unsupported', () => {
+    expect(getCurrentSupportedLocale('ka', 'ru')).toBe('ru');
+  });
+});
+
+describe('getLocalizedPathnameForLocale', () => {
+  it('replaces an existing locale prefix', () => {
+    expect(getLocalizedPathnameForLocale('/en/settings', 'ru')).toBe('/ru/settings');
+  });
+
+  it('preserves query strings and hashes', () => {
+    expect(getLocalizedPathnameForLocale('/en/settings?tab=language#section', 'ru')).toBe(
+      '/ru/settings?tab=language#section',
+    );
+  });
+
+  it('adds a locale prefix when none is present', () => {
+    expect(getLocalizedPathnameForLocale('/settings', 'en')).toBe('/en/settings');
+  });
+
+  it('keeps locale-only paths valid', () => {
+    expect(getLocalizedPathnameForLocale('/en', 'ru')).toBe('/ru');
+  });
+});

--- a/apps/game-client/src/i18n/locale-utils.test.ts
+++ b/apps/game-client/src/i18n/locale-utils.test.ts
@@ -15,6 +15,11 @@ describe('getCurrentSupportedLocale', () => {
   it('falls back to the provided locale when resolved language is unsupported', () => {
     expect(getCurrentSupportedLocale('ka', 'ru')).toBe('ru');
   });
+
+  it('falls back to the default supported locale when no fallback is provided', () => {
+    expect(getCurrentSupportedLocale('ka')).toBe('en');
+    expect(getCurrentSupportedLocale(undefined)).toBe('en');
+  });
 });
 
 describe('getLocalizedPathnameForLocale', () => {

--- a/apps/game-client/src/i18n/locale-utils.ts
+++ b/apps/game-client/src/i18n/locale-utils.ts
@@ -1,0 +1,39 @@
+import { type SupportedLocale, supportedLocales } from './i18n-constants';
+
+export function getCurrentSupportedLocale(
+  resolvedLanguage: string | undefined,
+  fallbackLocale: SupportedLocale = supportedLocales[0],
+): SupportedLocale {
+  return (
+    supportedLocales.find(
+      (locale) => resolvedLanguage === locale || resolvedLanguage?.startsWith(`${locale}-`),
+    ) ?? fallbackLocale
+  );
+}
+
+export function getLocalizedPathnameForLocale(path: string, newLocale: SupportedLocale): string {
+  const queryStart = path.indexOf('?');
+  const hashStart = path.indexOf('#');
+  let suffixStart = path.length;
+
+  if (queryStart >= 0) {
+    suffixStart = queryStart;
+  } else if (hashStart >= 0) {
+    suffixStart = hashStart;
+  }
+
+  const pathOnly = path.slice(0, suffixStart);
+  const suffix = path.slice(suffixStart);
+  const segments = pathOnly.split('/').filter(Boolean);
+  const first = segments[0];
+
+  if (first && supportedLocales.includes(first as SupportedLocale)) {
+    const rest = segments.slice(1);
+    const basePath = rest.length > 0 ? `/${newLocale}/${rest.join('/')}` : `/${newLocale}`;
+    return basePath + suffix;
+  }
+
+  const trimmed = pathOnly.startsWith('/') ? pathOnly.slice(1) : pathOnly;
+  const basePath = trimmed ? `/${newLocale}/${trimmed}` : `/${newLocale}`;
+  return basePath + suffix;
+}

--- a/apps/game-client/src/i18n/resources/messages/en/common.ts
+++ b/apps/game-client/src/i18n/resources/messages/en/common.ts
@@ -12,6 +12,7 @@ export default {
     page_titles_by_pathname: {
       '/learn': 'Learn',
       '/not-found': 'Not Found',
+      '/settings': 'Settings',
       '/translit': 'Translit',
     },
   },
@@ -19,6 +20,7 @@ export default {
   dock: {
     main_links: {
       learn: 'Learn',
+      settings: 'Settings',
       translit: 'Translit',
     },
   },

--- a/apps/game-client/src/i18n/resources/messages/en/settings.ts
+++ b/apps/game-client/src/i18n/resources/messages/en/settings.ts
@@ -1,0 +1,8 @@
+export default {
+  language_section: 'Language',
+  current_language: 'Current language: {{language}}',
+  languages: {
+    en: 'English',
+    ru: 'Русский',
+  },
+} as const;

--- a/apps/game-client/src/i18n/resources/messages/ru/common.ts
+++ b/apps/game-client/src/i18n/resources/messages/ru/common.ts
@@ -12,6 +12,7 @@ export default {
     page_titles_by_pathname: {
       '/learn': 'Учить',
       '/not-found': 'Не найдено',
+      '/settings': 'Настройки',
       '/translit': 'Транслит',
     },
   },
@@ -19,6 +20,7 @@ export default {
   dock: {
     main_links: {
       learn: 'Учить',
+      settings: 'Настройки',
       translit: 'Транслит',
     },
   },

--- a/apps/game-client/src/i18n/resources/messages/ru/settings.ts
+++ b/apps/game-client/src/i18n/resources/messages/ru/settings.ts
@@ -1,0 +1,8 @@
+export default {
+  language_section: 'Язык',
+  current_language: 'Текущий язык: {{language}}',
+  languages: {
+    en: 'English',
+    ru: 'Русский',
+  },
+} as const;

--- a/apps/game-client/src/i18n/resources/resources-en.ts
+++ b/apps/game-client/src/i18n/resources/resources-en.ts
@@ -3,6 +3,7 @@ import enHome from '@game-client/i18n/resources/messages/en/home';
 import enLearn from '@game-client/i18n/resources/messages/en/learn';
 import enMetadata from '@game-client/i18n/resources/messages/en/metadata';
 import enNotFound from '@game-client/i18n/resources/messages/en/not-found';
+import enSettings from '@game-client/i18n/resources/messages/en/settings';
 import enTranslit from '@game-client/i18n/resources/messages/en/translit';
 
 export const enResources = {
@@ -11,5 +12,6 @@ export const enResources = {
   learn: enLearn,
   metadata: enMetadata,
   notFound: enNotFound,
+  settings: enSettings,
   translit: enTranslit,
 } as const;

--- a/apps/game-client/src/i18n/resources/resources-ru.ts
+++ b/apps/game-client/src/i18n/resources/resources-ru.ts
@@ -3,6 +3,7 @@ import ruHome from '@game-client/i18n/resources/messages/ru/home';
 import ruLearn from '@game-client/i18n/resources/messages/ru/learn';
 import ruMetadata from '@game-client/i18n/resources/messages/ru/metadata';
 import ruNotFound from '@game-client/i18n/resources/messages/ru/not-found';
+import ruSettings from '@game-client/i18n/resources/messages/ru/settings';
 import ruTranslit from '@game-client/i18n/resources/messages/ru/translit';
 import type { SameKeysAsReferenceResources } from '@game-client/i18n/resources/same-keys-as-reference-resources';
 
@@ -12,5 +13,6 @@ export const ruResources: SameKeysAsReferenceResources = {
   learn: ruLearn,
   metadata: ruMetadata,
   notFound: ruNotFound,
+  settings: ruSettings,
   translit: ruTranslit,
 };

--- a/apps/game-client/src/ui/screens/settings/settings-client.tsx
+++ b/apps/game-client/src/ui/screens/settings/settings-client.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import {
+  getCurrentSupportedLocale,
+  getLocalizedPathnameForLocale,
+  PREFERRED_LOCALE_KEY,
+  type SupportedLocale,
+  supportedLocales,
+} from '@game-client/i18n';
+import { useNavigation } from '@game-client/navigation';
+import { buttonIconClassNames } from '@game-client/ui/shared/components/game-app-bar/game-app-bar-elements';
+import { ResponsiveContainer } from '@kartuli/ui/components/containers/responsive-container';
+import { cn } from '@kartuli/ui/utils/cn';
+import clsx from 'clsx';
+import Cookies from 'js-cookie';
+import { useTranslation } from 'react-i18next';
+import { HiOutlineSwitchHorizontal } from 'react-icons/hi';
+import { IoLanguage } from 'react-icons/io5';
+
+function LanguageSwitchButton({
+  locale,
+  label,
+  onClick,
+}: Readonly<{
+  locale: SupportedLocale;
+  label: string;
+  onClick: (locale: SupportedLocale) => void;
+}>) {
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(locale)}
+      className={clsx(
+        buttonIconClassNames,
+        'inline-flex items-center gap-3 rounded-xl px-4 py-3',
+        'w-full sm:w-auto',
+        'text-left font-bold text-ds1-color-text-900',
+      )}
+      aria-label={label}
+    >
+      <HiOutlineSwitchHorizontal className="size-5 shrink-0 text-ds1-color-text-700" />
+      <span>{label}</span>
+    </button>
+  );
+}
+
+export function SettingsClient({
+  initialLocale,
+}: Readonly<{
+  initialLocale: SupportedLocale;
+}>) {
+  const { t } = useTranslation('settings');
+  const { i18n } = useTranslation('common');
+  const { localizedPathname, navigate } = useNavigation();
+  const currentLocale = getCurrentSupportedLocale(i18n.resolvedLanguage, initialLocale);
+  const currentLanguageLabel = t(`languages.${currentLocale}`);
+  const switchableLocales = supportedLocales.filter((locale) => locale !== currentLocale);
+
+  const handleLanguageSwitch = (locale: SupportedLocale) => {
+    Cookies.set(PREFERRED_LOCALE_KEY, locale, { path: '/' });
+    const newPath = getLocalizedPathnameForLocale(localizedPathname, locale);
+    i18n.changeLanguage(locale).then(() => {
+      navigate(newPath);
+    });
+  };
+
+  return (
+    <ResponsiveContainer className="py-ds1-spacing-xlarge sm:py-ds1-spacing-3xlarge">
+      <section
+        aria-labelledby="settings-language-section-title"
+        className={cn(
+          'flex w-full flex-col gap-ds1-spacing-large',
+          'rounded-3xl border border-ds1-color-text-300 bg-ds1-color-text-50',
+          'p-ds1-spacing-large sm:p-ds1-spacing-xlarge',
+          'shadow-sm',
+        )}
+      >
+        <div className="flex items-center gap-3">
+          <div
+            className={cn(
+              'flex size-11 shrink-0 items-center justify-center rounded-full',
+              'border border-ds1-color-text-300 bg-ds1-color-text-200',
+            )}
+            aria-hidden="true"
+          >
+            <IoLanguage className="size-5 text-ds1-color-text-700" />
+          </div>
+          <h2
+            id="settings-language-section-title"
+            className="text-sm font-extrabold uppercase tracking-[0.18em] text-ds1-color-text-600"
+          >
+            {t('language_section')}
+          </h2>
+        </div>
+
+        <p className="text-lg font-semibold text-ds1-color-text-900">
+          {t('current_language', { language: currentLanguageLabel })}
+        </p>
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+          {switchableLocales.map((locale) => (
+            <LanguageSwitchButton
+              key={locale}
+              locale={locale}
+              label={t(`languages.${locale}`)}
+              onClick={handleLanguageSwitch}
+            />
+          ))}
+        </div>
+      </section>
+    </ResponsiveContainer>
+  );
+}

--- a/apps/game-client/src/ui/screens/settings/settings-page-server.tsx
+++ b/apps/game-client/src/ui/screens/settings/settings-page-server.tsx
@@ -1,0 +1,15 @@
+import { type SupportedLocale, supportedLocales } from '@game-client/i18n';
+import { SettingsClient } from './settings-client';
+
+export async function SettingsPageServer({
+  params,
+}: Readonly<{
+  params: Promise<{ locale: string }>;
+}>) {
+  const { locale } = await params;
+  const initialLocale = supportedLocales.includes(locale as SupportedLocale)
+    ? (locale as SupportedLocale)
+    : supportedLocales[0];
+
+  return <SettingsClient initialLocale={initialLocale} />;
+}

--- a/apps/game-client/src/ui/shared/components/game-app-bar/language-selector.tsx
+++ b/apps/game-client/src/ui/shared/components/game-app-bar/language-selector.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import { Select } from '@base-ui/react/select';
-import { PREFERRED_LOCALE_KEY, type SupportedLocale, supportedLocales } from '@game-client/i18n';
+import {
+  getCurrentSupportedLocale,
+  getLocalizedPathnameForLocale,
+  PREFERRED_LOCALE_KEY,
+  type SupportedLocale,
+  supportedLocales,
+} from '@game-client/i18n';
 import { useNavigation } from '@game-client/navigation/navigation-context';
 import {
   buttonIconClassNames,
@@ -12,37 +18,10 @@ import Cookies from 'js-cookie';
 import { useTranslation } from 'react-i18next';
 import { IoLanguage } from 'react-icons/io5';
 
-const getNewPathForNewLocale = (path: string, newLocale: string) => {
-  const queryStart = path.indexOf('?');
-  const hashStart = path.indexOf('#');
-  let suffixStart = path.length;
-  if (queryStart >= 0) {
-    suffixStart = queryStart;
-  } else if (hashStart >= 0) {
-    suffixStart = hashStart;
-  }
-  const pathOnly = path.slice(0, suffixStart);
-  const suffix = path.slice(suffixStart);
-  const segments = pathOnly.split('/').filter(Boolean);
-  const first = segments[0];
-  if (first && supportedLocales.includes(first as SupportedLocale)) {
-    const rest = segments.slice(1);
-    const basePath = rest.length > 0 ? `/${newLocale}/${rest.join('/')}` : `/${newLocale}`;
-    return basePath + suffix;
-  }
-  const trimmed = pathOnly.startsWith('/') ? pathOnly.slice(1) : pathOnly;
-  const basePath = trimmed ? `/${newLocale}/${trimmed}` : `/${newLocale}`;
-  return basePath + suffix;
-};
-
 export function LanguageSelector() {
   const { t, i18n } = useTranslation('common');
   const { navigate, localizedPathname } = useNavigation();
-  const currentLanguage = i18n.resolvedLanguage;
-  const currentLocale: SupportedLocale =
-    supportedLocales.find(
-      (locale) => currentLanguage === locale || currentLanguage?.startsWith(`${locale}-`),
-    ) ?? supportedLocales[0];
+  const currentLocale = getCurrentSupportedLocale(i18n.resolvedLanguage);
 
   const languageOptions = supportedLocales.map((locale) => ({
     value: locale,
@@ -54,10 +33,15 @@ export function LanguageSelector() {
   const activeShortLabel = activeLanguageLabel.slice(0, 3).toUpperCase();
 
   const handleValueChange = (value: string | null) => {
-    if (!value || value === currentLocale) return;
-    Cookies.set(PREFERRED_LOCALE_KEY, value, { path: '/' });
-    const newPath = getNewPathForNewLocale(localizedPathname, value);
-    i18n.changeLanguage(value).then(() => {
+    if (!value || value === currentLocale || !supportedLocales.includes(value as SupportedLocale)) {
+      return;
+    }
+
+    const locale = value as SupportedLocale;
+
+    Cookies.set(PREFERRED_LOCALE_KEY, locale, { path: '/' });
+    const newPath = getLocalizedPathnameForLocale(localizedPathname, locale);
+    i18n.changeLanguage(locale).then(() => {
       navigate(newPath);
     });
   };

--- a/apps/game-client/src/ui/shared/components/game-app-dock/game-app-dock-main-links.tsx
+++ b/apps/game-client/src/ui/shared/components/game-app-dock/game-app-dock-main-links.tsx
@@ -1,10 +1,12 @@
 'use client';
+import { getCurrentSupportedLocale } from '@game-client/i18n';
 import { useNavigation } from '@game-client/navigation/navigation-context';
 import { cn } from '@kartuli/ui/utils/cn';
 import type { TFunction } from 'i18next';
 import { AnimatePresence, motion } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { IoSettingsOutline, IoSettingsSharp } from 'react-icons/io5';
 import {
   PiArrowsClockwiseBold,
   PiArrowsClockwiseLight,
@@ -25,6 +27,12 @@ const mainLinks = [
     labelKey: 'translit',
     iconActive: PiArrowsClockwiseBold,
     iconInactive: PiArrowsClockwiseLight,
+  },
+  {
+    href: '/settings',
+    labelKey: 'settings',
+    iconActive: IoSettingsSharp,
+    iconInactive: IoSettingsOutline,
   },
 ];
 
@@ -67,7 +75,7 @@ export function DockMainLinkActiveIndicator({ isActive }: Readonly<{ isActive: b
 export function GameAppDockMainLinks() {
   const { pathname, NavigationLink } = useNavigation();
   const { i18n, t } = useTranslation('common');
-  const locale = i18n.resolvedLanguage;
+  const locale = getCurrentSupportedLocale(i18n.resolvedLanguage);
   const [touchedLink, setTouchedLink] = useState<string | null>(null);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 


### PR DESCRIPTION
Description:
## Description
Adds a localized `/settings` route (static params per supported locale) with a settings screen focused on language: current language display, switch actions that persist the preferred locale cookie, update i18next, and navigate to the same path under the new locale prefix.

Introduces `locale-utils` (`getCurrentSupportedLocale`, `getLocalizedPathnameForLocale`) with Vitest coverage for region subtags, fallbacks, and query/hash preservation. Refactors the app bar language selector to use these helpers instead of inline path logic, and tightens change handling to only accept supported locales.

Registers settings in EN/RU message bundles (including dock label and page title), adds a settings entry to the main dock with outline/filled icons, and exports the new helpers from the game-client i18n index.

---

## Linked Issues
<!-- Link related issues using GitHub keywords to automatically close them when this PR is merged -->
<!-- Examples: "Closes #123", "Fixes #456", "Resolves #789" -->

Closes #

---

## Type
<!-- Check the type of change. This should match your PR title prefix -->

- [x] `feat` - New feature
- [ ] `chore` - Infrastructure, setup tasks, non-feature work
- [ ] `fix` - Bug fix
- [ ] `docs` - Documentation changes
- [ ] `test` - Testing-related changes

---

## Scope
<!-- Check which part(s) of the monorepo this PR affects -->

- [x] `game-client` - Game client application
- [ ] `backoffice-client` - Backoffice client application
- [ ] `ui` - UI package
- [ ] `storybook` - Storybook tool
- [ ] `e2e` - E2E testing
- [ ] `global` - Shared packages or general repository tasks

---

## Screenshots (Optional)
<!-- If applicable, add screenshots to help explain your changes -->

N/A

---

## Preview Links (Optional)
<!-- If applicable, add links to preview deployments or live demos -->

N/A

---

## Testing Notes
<!-- Describe how you tested your changes and what reviewers should verify -->

- [ ] Tests pass locally
- [ ] Linting passes

<!-- Add specific testing instructions below -->

Open `/{locale}/settings`, confirm language section copy and switching updates URL, cookie, and UI. Exercise the app bar language selector on various routes (with and without locale prefix, query/hash if applicable). Run `vitest` for `apps/game-client` covering `locale-utils.test.ts`.

---

## Documentation Changes (if applicable)
<!-- If you modified documentation in /docs/, check what applies -->

- [ ] Added or updated documentation files
- [ ] Updated cross-references in other docs (if files were renamed/moved)
- [ ] Verified all internal links still work
- [x] N/A - No documentation changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Settings page with language switching capability
  * Users can now select their preferred language (English or Russian)
  * Settings link now appears in the main navigation dock
  * Localized Settings page and navigation text for all supported languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->