### PR TITLE
fix(global): exclude Turbo NONEXISTENT tasks from affected package detection

### DIFF
--- a/scripts/orchestrator/detect-affected.mjs
+++ b/scripts/orchestrator/detect-affected.mjs
@@ -15,9 +15,15 @@ function run(command, args, options = {}) {
 
 function packagesFromTurboJson(turboJson) {
   const tasks = Array.isArray(turboJson?.tasks) ? turboJson.tasks : [];
-  return [...new Set(tasks.map((task) => task?.package).filter(Boolean))].sort((a, b) =>
-    a.localeCompare(b),
-  );
+  return [
+    ...new Set(
+      tasks
+        // Turbo includes graph-only nodes for missing scripts; they should not
+        // be reported as affected packages.
+        .filter((task) => task?.package && task?.command !== '<NONEXISTENT>')
+        .map((task) => task.package),
+    ),
+  ].sort((a, b) => a.localeCompare(b));
 }
 
 function parseMode() {


### PR DESCRIPTION
Description:
## Description
Turbo can emit graph-only tasks for packages whose script is missing, with `command` set to `<NONEXISTENT>`. Those entries were being treated like real packages, so `packagesFromTurboJson` could report bogus “affected” packages. This change filters those tasks out before collecting package names, so affected detection only lists packages that actually run a command.

---

## Linked Issues

N/A

---

## Type

- [ ] `feat` - New feature
- [ ] `chore` - Infrastructure, setup tasks, non-feature work
- [x] `fix` - Bug fix
- [ ] `docs` - Documentation changes
- [ ] `test` - Testing-related changes

---

## Scope

- [ ] `game-client` - Game client application
- [ ] `backoffice-client` - Backoffice client application
- [ ] `ui` - UI package
- [ ] `storybook` - Storybook tool
- [ ] `e2e` - E2E testing
- [x] `global` - Shared packages or general repository tasks

---

## Screenshots (Optional)

N/A

---

## Preview Links (Optional)

N/A

---

## Testing Notes

- [ ] Tests pass locally
- [ ] Linting passes

Run the orchestrator affected path that uses `detect-affected.mjs` (or invoke it with the same `turbo.json` inputs you use in CI) and confirm listed packages match real tasks only—no phantom packages from missing scripts. If you still have a local commit message about the game-client app bar, consider amending or splitting so the commit matches this change.

---

## Documentation Changes (if applicable)

- [ ] Added or updated documentation files
- [ ] Updated cross-references in other docs (if files were renamed/moved)
- [ ] Verified all internal links still work
- [x] N/A - No documentation changes
