### PR TITLE
feat(game-client): improve study summary layout and slide gestures

### DIFF
--- a/apps/game-client/src/ui/components/actions/panel-action-button.tsx
+++ b/apps/game-client/src/ui/components/actions/panel-action-button.tsx
@@ -27,6 +27,7 @@ const panelActionButtonClassName = cn(
   'size-11',
   'active:scale-95',
   'cursor-pointer',
+  'shadow-md',
 );
 
 export interface PanelActionButtonProps

--- a/apps/game-client/src/ui/components/actions/shell-action.tsx
+++ b/apps/game-client/src/ui/components/actions/shell-action.tsx
@@ -112,6 +112,7 @@ export function ShellActionButton({
       className={cn(
         getShellActionClassName({ className, size, variant }),
         'disabled:cursor-not-allowed disabled:opacity-20',
+        'shadow-md',
       )}
       {...buttonProps}
     >

--- a/apps/game-client/src/ui/components/layout/dock/dock-item.tsx
+++ b/apps/game-client/src/ui/components/layout/dock/dock-item.tsx
@@ -38,6 +38,7 @@ export function DockItem({
         active && 'bg-s-color-shell-action-selected-bg',
         active && 'text-s-color-shell-action-selected-content',
         active && 'focus-visible:ring-s-color-shell-action-selected-ring',
+        active && 'shadow-md',
         'rounded-p-radius-1',
         'outline-none',
         'uppercase',

--- a/apps/game-client/src/ui/components/panel/panel-link-hover-frame.tsx
+++ b/apps/game-client/src/ui/components/panel/panel-link-hover-frame.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@kartuli/ui/utils/cn';
+
+export function PanelLinkHoverFrame() {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        'pointer-events-none',
+        'absolute inset-0 z-10',
+        'rounded-[inherit]',
+        'border-0',
+        'group-hover:border-(length:--s-width-panel-border)',
+        'group-hover:border-s-color-panel-border-hover',
+      )}
+    />
+  );
+}

--- a/apps/game-client/src/ui/components/panel/panel-section.tsx
+++ b/apps/game-client/src/ui/components/panel/panel-section.tsx
@@ -7,5 +7,5 @@ interface PanelSectionProps {
 }
 
 export function PanelSection({ children, className }: Readonly<PanelSectionProps>) {
-  return <div className={cn('w-full', 'px-4', 'py-2', 'gap-4', className)}>{children}</div>;
+  return <div className={cn('w-full', 'px-4', 'py-2', className)}>{children}</div>;
 }

--- a/apps/game-client/src/ui/components/panel/panel-section.tsx
+++ b/apps/game-client/src/ui/components/panel/panel-section.tsx
@@ -7,5 +7,5 @@ interface PanelSectionProps {
 }
 
 export function PanelSection({ children, className }: Readonly<PanelSectionProps>) {
-  return <div className={cn('w-full', 'px-4', 'py-2', className)}>{children}</div>;
+  return <div className={cn('w-full', 'px-4', 'py-2', 'gap-4', className)}>{children}</div>;
 }

--- a/apps/game-client/src/ui/components/panel/panel.stories.tsx
+++ b/apps/game-client/src/ui/components/panel/panel.stories.tsx
@@ -7,6 +7,7 @@ import { PiStudent } from 'react-icons/pi';
 import { Surface } from '../surface/surface';
 import { Panel } from './panel';
 import { PanelHeader } from './panel-header';
+import { PanelLinkHoverFrame } from './panel-link-hover-frame';
 import { PanelSection } from './panel-section';
 
 type PanelHeaderLeadingMode = 'none' | 'icon';
@@ -114,7 +115,8 @@ function PanelStory({
   interactive,
 }: Readonly<PanelStoryProps>) {
   const panel = (
-    <Panel className={interactive ? 'hover:border-s-color-panel-border-hover' : undefined}>
+    <Panel className={interactive ? 'relative' : undefined}>
+      {interactive && <PanelLinkHoverFrame />}
       <PanelHeader
         context={context}
         title={title}

--- a/apps/game-client/src/ui/components/panel/panel.tsx
+++ b/apps/game-client/src/ui/components/panel/panel.tsx
@@ -15,11 +15,10 @@ export function Panel({ children, className }: Readonly<PanelProps>) {
         'flex',
         'flex-col',
         'overflow-hidden',
-        'rounded-p-radius-1',
-        'border-(length:--s-width-panel-border)',
-        'border-s-color-panel-border',
+        'rounded-p-radius-2',
         'bg-s-color-panel-bg',
-        'shadow-sm',
+        'shadow-md',
+        // 'border border-red-500',
         className,
       )}
     >

--- a/apps/game-client/src/ui/components/panel/panel.tsx
+++ b/apps/game-client/src/ui/components/panel/panel.tsx
@@ -18,7 +18,6 @@ export function Panel({ children, className }: Readonly<PanelProps>) {
         'rounded-p-radius-2',
         'bg-s-color-panel-bg',
         'shadow-md',
-        // 'border border-red-500',
         className,
       )}
     >

--- a/apps/game-client/src/ui/experiences/explore/pages/explore-alphabet/alphabet-explore-content.tsx
+++ b/apps/game-client/src/ui/experiences/explore/pages/explore-alphabet/alphabet-explore-content.tsx
@@ -3,6 +3,7 @@ import { getLibraryServer } from '@game-client/learning-content/library/get-libr
 import type { Lesson, LetterItem, Library } from '@game-client/learning-content/library/library';
 import { Panel } from '@game-client/ui/components/panel/panel';
 import { PanelHeader } from '@game-client/ui/components/panel/panel-header';
+import { PanelLinkHoverFrame } from '@game-client/ui/components/panel/panel-link-hover-frame';
 import { PanelSection } from '@game-client/ui/components/panel/panel-section';
 import { ModuleCardsLayout } from '@game-client/ui/experiences/explore/components/module-cards-layout';
 import { cn } from '@kartuli/ui/utils/cn';
@@ -40,12 +41,16 @@ function getDataFromLibrary(library: Library) {
 }
 
 const linkCardClassName = cn(
-  'flex grow cursor-pointer active:scale-95',
+  'group flex grow cursor-pointer active:scale-95',
+  'outline-none',
   'focus-visible:ring-(length:--s-width-focus-ring)',
   'focus-visible:ring-s-color-panel-border-hover',
-  'outline-none',
-  'rounded-p-radius-1',
+  'rounded-p-radius-2',
 );
+
+const linkPanelClassName = cn('relative border-0');
+
+const linkPanelHeaderClassName = 'rounded-t-[inherit]';
 
 export async function AlphabetExploreContent({ locale }: Readonly<{ locale: SupportedLocale }>) {
   const alphabetMessages = getMessagesForLocale(locale, 'alphabet');
@@ -62,9 +67,15 @@ export async function AlphabetExploreContent({ locale }: Readonly<{ locale: Supp
             linkCardClassName,
           )}
         >
-          <Panel className="hover:border-s-color-panel-border-hover">
-            <PanelHeader context={alphabetMessages.title} title={lesson.name} variant="default" />
-            <PanelSection className="flex gap-4">
+          <Panel className={linkPanelClassName}>
+            <PanelLinkHoverFrame />
+            <PanelHeader
+              className={linkPanelHeaderClassName}
+              context={alphabetMessages.title}
+              title={lesson.name}
+              variant="default"
+            />
+            <PanelSection>
               <LettersPreviewGrid items={lesson.items} size="grid-item" />
             </PanelSection>
           </Panel>
@@ -79,14 +90,16 @@ export async function AlphabetExploreContent({ locale }: Readonly<{ locale: Supp
               linkCardClassName,
             )}
           >
-            <Panel className="hover:border-s-color-panel-border-hover">
+            <Panel className={linkPanelClassName}>
+              <PanelLinkHoverFrame />
               <PanelHeader
+                className={linkPanelHeaderClassName}
                 context={alphabetMessages.title}
                 title={alphabetMessages.full_review}
                 variant="inverted"
                 leading={<PiStudent className="size-11" aria-hidden="true" />}
               />
-              <PanelSection className="flex gap-4">
+              <PanelSection>
                 <LettersPreviewGrid items={allItemsDeduplicated} size="full" />
               </PanelSection>
             </Panel>

--- a/apps/game-client/src/ui/experiences/study/components/detail/letter-study-detail-content.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/detail/letter-study-detail-content.tsx
@@ -14,7 +14,7 @@ export function LetterStudyDetailContent({ item }: Readonly<LetterStudyDetailCon
         <span className="absolute top-6/10 left-0 z-10 h-[1cqw] w-full bg-s-color-panel-content-notebook-line"></span>
         <span className="relative z-50 mx-auto">{item.targetScript}</span>
       </div>
-      <div className="flex items-center justify-center gap-1 text-[10cqw] text-s-color-panel-content-secondary">
+      <div className="flex items-center justify-center gap-1 text-[10cqw] text-s-color-panel-content-primary">
         <span className="text-s-color-panel-content-transliteration-bracket">[</span>
         <span className="flex">{item.transliteration}</span>
         <span className="text-s-color-panel-content-transliteration-bracket">]</span>

--- a/apps/game-client/src/ui/experiences/study/components/study-cta-button.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/study-cta-button.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ShellActionButton } from '@game-client/ui/components/actions/shell-action';
+import { cn } from '@kartuli/ui/utils/cn';
 import type { ComponentType, SVGProps } from 'react';
 
 export function StudyCtaButton({
@@ -20,7 +21,7 @@ export function StudyCtaButton({
     <ShellActionButton
       aria-label={label}
       onClick={onClick}
-      className={className}
+      className={cn(className)}
       size="cta"
       variant="primary"
     >

--- a/apps/game-client/src/ui/experiences/study/components/study-cta-button.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/study-cta-button.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { ShellActionButton } from '@game-client/ui/components/actions/shell-action';
-import { cn } from '@kartuli/ui/utils/cn';
 import type { ComponentType, SVGProps } from 'react';
 
 export function StudyCtaButton({
@@ -21,7 +20,7 @@ export function StudyCtaButton({
     <ShellActionButton
       aria-label={label}
       onClick={onClick}
-      className={cn(className)}
+      className={className}
       size="cta"
       variant="primary"
     >

--- a/apps/game-client/src/ui/experiences/study/components/study-navigation.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/study-navigation.tsx
@@ -18,7 +18,7 @@ export function NavigationBar(props: Readonly<StudyNavigationModel>) {
   } = props;
 
   return (
-    <div className="hidden w-full grid-cols-[minmax(0,1fr)_auto_auto_minmax(0,1fr)] items-center gap-3 md:grid">
+    <div className="hidden w-full grid-cols-[minmax(0,1fr)_auto_auto_minmax(0,1fr)] items-center gap-3 md:grid px-1">
       <div className="flex min-w-0 items-center justify-center">
         <StudyNavigationButton
           className="w-full min-w-0"
@@ -67,7 +67,7 @@ export function MobileInfoBar(props: Readonly<StudyNavigationModel>) {
   } = props;
 
   return (
-    <div className="grid w-full grid-cols-[minmax(0,1fr)_auto_auto_minmax(0,1fr)] items-center gap-2 md:hidden">
+    <div className="grid w-full grid-cols-[minmax(0,1fr)_auto_auto_minmax(0,1fr)] items-center gap-2 md:hidden px-1">
       <div className="flex min-w-0 items-center justify-center">
         <StudyNavigationButton
           className="w-full"

--- a/apps/game-client/src/ui/experiences/study/components/study-screen-layout.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/study-screen-layout.tsx
@@ -11,11 +11,11 @@ import { PiPlayFill } from 'react-icons/pi';
 
 export function StudyScreenLayout({ nav }: Readonly<{ nav: StudyNavigationModel }>) {
   return (
-    <div className="flex flex-1 min-h-0 min-w-0 flex-col gap-4 h-full max-w-[600px] w-full mx-auto">
+    <div className="flex flex-1 min-h-0 min-w-0 flex-col gap-2 h-full max-w-[600px] w-full mx-auto">
       <NavigationBar {...nav} />
       <StudySlidesCarousel nav={nav} />
       <MobileInfoBar {...nav} />
-      <div className="flex w-full">
+      <div className="flex w-full px-1">
         <StudyCtaButton label="Play now" icon={PiPlayFill} />
       </div>
     </div>

--- a/apps/game-client/src/ui/experiences/study/components/study-slide-pointer-swipe.test.ts
+++ b/apps/game-client/src/ui/experiences/study/components/study-slide-pointer-swipe.test.ts
@@ -1,9 +1,80 @@
-import { describe, expect, it } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import type { MotionValue } from 'motion/react';
+import type { PointerEvent as ReactPointerEvent } from 'react';
+import { describe, expect, it, vi } from 'vitest';
 import {
   clampStudyTrackOffsetX,
   classifyStudyPointerGesture,
   STUDY_POINTER_GESTURE_SLOP_PX,
+  useStudySummarySlidePointerSwipe,
 } from './study-slide-pointer-swipe';
+
+interface CapturedPointerInit {
+  pointerId: number;
+  clientX: number;
+  clientY?: number;
+  timeStamp?: number;
+}
+
+function dispatchCapturedPointer(
+  handlers: ReturnType<typeof useStudySummarySlidePointerSwipe>,
+  target: HTMLElement,
+  type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel',
+  init: CapturedPointerInit,
+) {
+  const handlerName =
+    type === 'pointerdown'
+      ? 'onPointerDownCapture'
+      : type === 'pointermove'
+        ? 'onPointerMoveCapture'
+        : type === 'pointerup'
+          ? 'onPointerUpCapture'
+          : 'onPointerCancelCapture';
+
+  const handler = handlers[handlerName];
+  const nativeEvent = new PointerEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    isPrimary: true,
+    button: 0,
+    buttons: type === 'pointerdown' ? 1 : 0,
+    pointerId: init.pointerId,
+    clientX: init.clientX,
+    clientY: init.clientY ?? 0,
+  });
+
+  handler({
+    pointerId: init.pointerId,
+    clientX: init.clientX,
+    clientY: init.clientY ?? 0,
+    timeStamp: init.timeStamp ?? 0,
+    isPrimary: true,
+    button: 0,
+    currentTarget: target,
+    preventDefault: () => nativeEvent.preventDefault(),
+  } as ReactPointerEvent<HTMLElement>);
+}
+
+function runHorizontalSwipe(
+  handlers: ReturnType<typeof useStudySummarySlidePointerSwipe>,
+  target: HTMLElement,
+  endType: 'pointerup' | 'pointercancel',
+) {
+  act(() => {
+    dispatchCapturedPointer(handlers, target, 'pointerdown', { pointerId: 1, clientX: 100 });
+    dispatchCapturedPointer(handlers, target, 'pointermove', {
+      pointerId: 1,
+      clientX: 160,
+      timeStamp: 16,
+    });
+    dispatchCapturedPointer(handlers, target, 'pointermove', {
+      pointerId: 1,
+      clientX: 200,
+      timeStamp: 32,
+    });
+    dispatchCapturedPointer(handlers, target, endType, { pointerId: 1, clientX: 200 });
+  });
+}
 
 describe('classifyStudyPointerGesture', () => {
   it('stays pending inside the slop box', () => {
@@ -34,5 +105,47 @@ describe('clampStudyTrackOffsetX', () => {
 
   it('clamps to the last slide', () => {
     expect(clampStudyTrackOffsetX(-200, 3, slideStride, lastSlideIndex)).toBe(-1200);
+  });
+});
+
+describe('useStudySummarySlidePointerSwipe', () => {
+  const slideStride = 400;
+
+  function renderSwipeHook() {
+    const target = document.createElement('div');
+    const onSwipeEnd = vi.fn();
+    const trackX = { set: vi.fn() } as unknown as MotionValue<number>;
+
+    const { result } = renderHook(() =>
+      useStudySummarySlidePointerSwipe({
+        enabled: true,
+        currentSlideIndex: 0,
+        slideStride,
+        lastSlideIndex: 3,
+        trackX,
+        stopTrackAnimation: vi.fn(),
+        onSwipeEnd,
+      }),
+    );
+
+    return { target, onSwipeEnd, handlers: result.current };
+  }
+
+  it('ends a horizontal swipe with offset and velocity on pointerup', () => {
+    const { target, onSwipeEnd, handlers } = renderSwipeHook();
+
+    runHorizontalSwipe(handlers, target, 'pointerup');
+
+    expect(onSwipeEnd).toHaveBeenCalledOnce();
+    expect(onSwipeEnd).toHaveBeenCalledWith({ offsetX: 100, velocityX: 2500 });
+  });
+
+  it('aborts a horizontal swipe without navigation signal on pointercancel', () => {
+    const { target, onSwipeEnd, handlers } = renderSwipeHook();
+
+    runHorizontalSwipe(handlers, target, 'pointercancel');
+
+    expect(onSwipeEnd).toHaveBeenCalledOnce();
+    expect(onSwipeEnd).toHaveBeenCalledWith({ offsetX: 0, velocityX: 0 });
   });
 });

--- a/apps/game-client/src/ui/experiences/study/components/study-slide-pointer-swipe.test.ts
+++ b/apps/game-client/src/ui/experiences/study/components/study-slide-pointer-swipe.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clampStudyTrackOffsetX,
+  classifyStudyPointerGesture,
+  STUDY_POINTER_GESTURE_SLOP_PX,
+} from './study-slide-pointer-swipe';
+
+describe('classifyStudyPointerGesture', () => {
+  it('stays pending inside the slop box', () => {
+    expect(classifyStudyPointerGesture(4, 4)).toBe('pending');
+    expect(classifyStudyPointerGesture(STUDY_POINTER_GESTURE_SLOP_PX - 1, 0)).toBe('pending');
+  });
+
+  it('chooses horizontal when horizontal movement dominates', () => {
+    expect(classifyStudyPointerGesture(24, 4)).toBe('horizontal');
+  });
+
+  it('chooses vertical when vertical movement dominates', () => {
+    expect(classifyStudyPointerGesture(4, 24)).toBe('vertical');
+  });
+});
+
+describe('clampStudyTrackOffsetX', () => {
+  const slideStride = 400;
+  const lastSlideIndex = 3;
+
+  it('offsets from the current slide rest position', () => {
+    expect(clampStudyTrackOffsetX(-80, 1, slideStride, lastSlideIndex)).toBe(-480);
+  });
+
+  it('clamps to the first slide', () => {
+    expect(clampStudyTrackOffsetX(120, 0, slideStride, lastSlideIndex)).toBe(0);
+  });
+
+  it('clamps to the last slide', () => {
+    expect(clampStudyTrackOffsetX(-200, 3, slideStride, lastSlideIndex)).toBe(-1200);
+  });
+});

--- a/apps/game-client/src/ui/experiences/study/components/study-slide-pointer-swipe.ts
+++ b/apps/game-client/src/ui/experiences/study/components/study-slide-pointer-swipe.ts
@@ -1,0 +1,174 @@
+'use client';
+
+import type { MotionValue } from 'motion/react';
+import type { PointerEvent as ReactPointerEvent } from 'react';
+import { useRef } from 'react';
+
+export const STUDY_POINTER_GESTURE_SLOP_PX = 10;
+
+export type StudyPointerGestureMode = 'pending' | 'horizontal' | 'vertical';
+
+export function classifyStudyPointerGesture(
+  deltaX: number,
+  deltaY: number,
+  slopPx = STUDY_POINTER_GESTURE_SLOP_PX,
+): StudyPointerGestureMode {
+  if (Math.abs(deltaX) < slopPx && Math.abs(deltaY) < slopPx) return 'pending';
+
+  return Math.abs(deltaX) > Math.abs(deltaY) ? 'horizontal' : 'vertical';
+}
+
+export function clampStudyTrackOffsetX(
+  dragOffsetX: number,
+  currentSlideIndex: number,
+  slideStride: number,
+  lastSlideIndex: number,
+): number {
+  const restOffsetX = -currentSlideIndex * slideStride;
+  const minOffsetX = -lastSlideIndex * slideStride;
+  const maxOffsetX = 0;
+
+  return Math.max(minOffsetX, Math.min(maxOffsetX, restOffsetX + dragOffsetX));
+}
+
+interface StudySummarySlidePointerSwipeEndInfo {
+  offsetX: number;
+  velocityX: number;
+}
+
+interface UseStudySummarySlidePointerSwipeOptions {
+  enabled: boolean;
+  currentSlideIndex: number;
+  slideStride: number;
+  lastSlideIndex: number;
+  trackX: MotionValue<number>;
+  stopTrackAnimation: () => void;
+  onSwipeEnd: (info: StudySummarySlidePointerSwipeEndInfo) => void;
+}
+
+interface PointerGestureState {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  lastX: number;
+  lastTime: number;
+  velocityX: number;
+  mode: StudyPointerGestureMode;
+  captureTarget: HTMLElement | null;
+}
+
+function createInitialGestureState(): PointerGestureState {
+  return {
+    pointerId: -1,
+    startX: 0,
+    startY: 0,
+    lastX: 0,
+    lastTime: 0,
+    velocityX: 0,
+    mode: 'pending',
+    captureTarget: null,
+  };
+}
+
+export function useStudySummarySlidePointerSwipe({
+  enabled,
+  currentSlideIndex,
+  slideStride,
+  lastSlideIndex,
+  trackX,
+  stopTrackAnimation,
+  onSwipeEnd,
+}: UseStudySummarySlidePointerSwipeOptions) {
+  const gestureRef = useRef<PointerGestureState>(createInitialGestureState());
+
+  const releaseCapturedPointer = () => {
+    const gesture = gestureRef.current;
+
+    if (!gesture.captureTarget || gesture.pointerId === -1) return;
+
+    try {
+      gesture.captureTarget.releasePointerCapture(gesture.pointerId);
+    } catch {
+      // Pointer capture may already be released.
+    }
+  };
+
+  const resetGesture = () => {
+    releaseCapturedPointer();
+    gestureRef.current = createInitialGestureState();
+  };
+
+  const onPointerDownCapture = (event: ReactPointerEvent<HTMLElement>) => {
+    if (!enabled || !event.isPrimary || event.button !== 0) return;
+
+    stopTrackAnimation();
+
+    const gesture = gestureRef.current;
+    gesture.pointerId = event.pointerId;
+    gesture.startX = event.clientX;
+    gesture.startY = event.clientY;
+    gesture.lastX = event.clientX;
+    gesture.lastTime = event.timeStamp;
+    gesture.velocityX = 0;
+    gesture.mode = 'pending';
+    gesture.captureTarget = event.currentTarget;
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const onPointerMoveCapture = (event: ReactPointerEvent<HTMLElement>) => {
+    const gesture = gestureRef.current;
+    if (!enabled || event.pointerId !== gesture.pointerId) return;
+
+    const deltaX = event.clientX - gesture.startX;
+    const deltaY = event.clientY - gesture.startY;
+
+    if (gesture.mode === 'pending') {
+      const mode = classifyStudyPointerGesture(deltaX, deltaY);
+
+      if (mode === 'pending') return;
+
+      gesture.mode = mode;
+
+      if (mode === 'vertical') {
+        resetGesture();
+        return;
+      }
+    }
+
+    if (gesture.mode !== 'horizontal') return;
+
+    event.preventDefault();
+    trackX.set(clampStudyTrackOffsetX(deltaX, currentSlideIndex, slideStride, lastSlideIndex));
+
+    const deltaTimeMs = event.timeStamp - gesture.lastTime;
+
+    if (deltaTimeMs > 0) {
+      gesture.velocityX = ((event.clientX - gesture.lastX) / deltaTimeMs) * 1000;
+    }
+
+    gesture.lastX = event.clientX;
+    gesture.lastTime = event.timeStamp;
+  };
+
+  const onPointerUpCapture = (event: ReactPointerEvent<HTMLElement>) => {
+    const gesture = gestureRef.current;
+    if (!enabled || event.pointerId !== gesture.pointerId) return;
+
+    if (gesture.mode === 'horizontal') {
+      event.preventDefault();
+      onSwipeEnd({
+        offsetX: event.clientX - gesture.startX,
+        velocityX: gesture.velocityX,
+      });
+    }
+
+    resetGesture();
+  };
+
+  return {
+    onPointerDownCapture,
+    onPointerMoveCapture,
+    onPointerUpCapture,
+    onPointerCancelCapture: onPointerUpCapture,
+  };
+}

--- a/apps/game-client/src/ui/experiences/study/components/study-slide-pointer-swipe.ts
+++ b/apps/game-client/src/ui/experiences/study/components/study-slide-pointer-swipe.ts
@@ -169,10 +169,21 @@ export function useStudySummarySlidePointerSwipe({
     resetGesture();
   };
 
+  const onPointerCancelCapture = (event: ReactPointerEvent<HTMLElement>) => {
+    const gesture = gestureRef.current;
+    if (!enabled || event.pointerId !== gesture.pointerId) return;
+
+    if (gesture.mode === 'horizontal') {
+      onSwipeEnd({ offsetX: 0, velocityX: 0 });
+    }
+
+    resetGesture();
+  };
+
   return {
     onPointerDownCapture,
     onPointerMoveCapture,
     onPointerUpCapture,
-    onPointerCancelCapture: onPointerUpCapture,
+    onPointerCancelCapture,
   };
 }

--- a/apps/game-client/src/ui/experiences/study/components/study-slide-pointer-swipe.ts
+++ b/apps/game-client/src/ui/experiences/study/components/study-slide-pointer-swipe.ts
@@ -112,7 +112,9 @@ export function useStudySummarySlidePointerSwipe({
     gesture.velocityX = 0;
     gesture.mode = 'pending';
     gesture.captureTarget = event.currentTarget;
-    event.currentTarget.setPointerCapture(event.pointerId);
+    // Capture is deferred to the first horizontal move so that taps on child
+    // buttons still receive their click event (setPointerCapture re-targets
+    // pointerup — and therefore click — to the capturing element).
   };
 
   const onPointerMoveCapture = (event: ReactPointerEvent<HTMLElement>) => {
@@ -133,6 +135,8 @@ export function useStudySummarySlidePointerSwipe({
         resetGesture();
         return;
       }
+
+      gesture.captureTarget?.setPointerCapture(gesture.pointerId);
     }
 
     if (gesture.mode !== 'horizontal') return;

--- a/apps/game-client/src/ui/experiences/study/components/study-slides-carousel.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/study-slides-carousel.tsx
@@ -194,7 +194,9 @@ export function StudySlidesCarousel({ nav }: Readonly<{ nav: StudyNavigationMode
   return (
     <div
       ref={viewportRef}
-      className={cn('relative flex flex-1 min-h-0 min-w-0 w-full overflow-hidden')}
+      className={cn(
+        'relative flex flex-1 min-h-0 min-w-0 w-full overflow-hidden rounded-p-radius-3',
+      )}
     >
       <div className="h-full min-h-0 w-full overflow-hidden">
         <motion.div

--- a/apps/game-client/src/ui/experiences/study/components/study-slides-carousel.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/study-slides-carousel.tsx
@@ -56,26 +56,17 @@ function getStudySlideAnimationDuration(fromSlideIndex: number, toSlideIndex: nu
 export function StudySlidesCarousel({ nav }: Readonly<{ nav: StudyNavigationModel }>) {
   const slides = useMemo(() => getStudySlides(nav.items), [nav.items]);
   const viewportRef = useRef<HTMLDivElement | null>(null);
-  const slideRefs = useRef<Array<HTMLElement | null>>([]);
   const trackX = useMotionValue(0);
   const [slideWidth, setSlideWidth] = useState(0);
   const hasInitializedTrackRef = useRef(false);
   const previousSlideIndexRef = useRef(nav.currentSlideIndex);
   const previousSlideWidthRef = useRef(0);
   const trackAnimationRef = useRef<{ stop: () => void } | null>(null);
-  const pendingFocusSlideIndexRef = useRef<number | null>(null);
   const slideStride = slideWidth > 0 ? slideWidth + STUDY_SLIDES_GAP_PX : 0;
 
   const stopTrackAnimation = () => {
     trackAnimationRef.current?.stop();
     trackAnimationRef.current = null;
-  };
-
-  const focusSlideIfNeeded = (slideIndex: number) => {
-    if (pendingFocusSlideIndexRef.current !== slideIndex) return;
-
-    slideRefs.current[slideIndex]?.focus();
-    pendingFocusSlideIndexRef.current = null;
   };
 
   const animateTrackToSlide = (fromSlideIndex: number, toSlideIndex: number) => {
@@ -87,7 +78,6 @@ export function StudySlidesCarousel({ nav }: Readonly<{ nav: StudyNavigationMode
       ease: 'easeOut',
       onComplete: () => {
         trackAnimationRef.current = null;
-        focusSlideIfNeeded(toSlideIndex);
       },
     });
   };
@@ -192,7 +182,6 @@ export function StudySlidesCarousel({ nav }: Readonly<{ nav: StudyNavigationMode
   });
 
   const handleSummaryItemSelect = (itemIndex: number) => {
-    pendingFocusSlideIndexRef.current = itemIndex + 1;
     nav.handleSelectItem(itemIndex);
   };
 
@@ -224,9 +213,6 @@ export function StudySlidesCarousel({ nav }: Readonly<{ nav: StudyNavigationMode
             return (
               <section
                 key={slide.key}
-                ref={(element) => {
-                  slideRefs.current[slideIndex] = element;
-                }}
                 aria-hidden={!isActive}
                 aria-label={
                   slide.kind === 'summary' ? 'Summary slide' : `Detail slide ${slide.itemIndex + 1}`
@@ -236,7 +222,6 @@ export function StudySlidesCarousel({ nav }: Readonly<{ nav: StudyNavigationMode
                 data-study-slide-index={slideIndex}
                 inert={!isActive}
                 style={{ width: individualSlideWidth }}
-                tabIndex={isActive ? -1 : undefined}
                 {...(slide.kind === 'summary' && isActive ? summarySlidePointerSwipe : {})}
               >
                 {slide.kind === 'summary' ? (

--- a/apps/game-client/src/ui/experiences/study/components/study-slides-carousel.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/study-slides-carousel.tsx
@@ -5,13 +5,17 @@ import { Panel } from '@game-client/ui/components/panel/panel';
 import { LetterStudyDetailSlide } from '@game-client/ui/experiences/study/components/detail/letter-study-detail-slide';
 import type { StudyNavigationModel } from '@game-client/ui/experiences/study/components/study-screen.types';
 import { getStudySwipeNavigationDirection } from '@game-client/ui/experiences/study/components/study-screen-swipe';
+import { useStudySummarySlidePointerSwipe } from '@game-client/ui/experiences/study/components/study-slide-pointer-swipe';
 import { LetterStudySummarySlide } from '@game-client/ui/experiences/study/components/summary/letter-study-summary-slide';
+import { cn } from '@kartuli/ui/utils/cn';
 import { animate, motion, type PanInfo, useMotionValue } from 'motion/react';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 const STUDY_SLIDE_ANIMATION_BASE_DURATION_SECONDS = 0.1;
 const STUDY_SLIDE_ANIMATION_EXTRA_DURATION_SECONDS = 0.02;
 const STUDY_SLIDE_ANIMATION_MAX_DURATION_SECONDS = 0.2;
+/** Matches `gap-p-spacing-6` / `--p-spacing-6` on the slides track. */
+const STUDY_SLIDES_GAP_PX = 64;
 
 type StudySlide =
   | {
@@ -60,6 +64,7 @@ export function StudySlidesCarousel({ nav }: Readonly<{ nav: StudyNavigationMode
   const previousSlideWidthRef = useRef(0);
   const trackAnimationRef = useRef<{ stop: () => void } | null>(null);
   const pendingFocusSlideIndexRef = useRef<number | null>(null);
+  const slideStride = slideWidth > 0 ? slideWidth + STUDY_SLIDES_GAP_PX : 0;
 
   const stopTrackAnimation = () => {
     trackAnimationRef.current?.stop();
@@ -74,10 +79,10 @@ export function StudySlidesCarousel({ nav }: Readonly<{ nav: StudyNavigationMode
   };
 
   const animateTrackToSlide = (fromSlideIndex: number, toSlideIndex: number) => {
-    if (slideWidth <= 0) return;
+    if (slideStride <= 0) return;
 
     stopTrackAnimation();
-    trackAnimationRef.current = animate(trackX, -toSlideIndex * slideWidth, {
+    trackAnimationRef.current = animate(trackX, -toSlideIndex * slideStride, {
       duration: getStudySlideAnimationDuration(fromSlideIndex, toSlideIndex),
       ease: 'easeOut',
       onComplete: () => {
@@ -95,7 +100,7 @@ export function StudySlidesCarousel({ nav }: Readonly<{ nav: StudyNavigationMode
     if (initialSlideWidth <= 0) return;
 
     setSlideWidth(initialSlideWidth);
-    trackX.set(-nav.currentSlideIndex * initialSlideWidth);
+    trackX.set(-nav.currentSlideIndex * (initialSlideWidth + STUDY_SLIDES_GAP_PX));
     previousSlideWidthRef.current = initialSlideWidth;
     previousSlideIndexRef.current = nav.currentSlideIndex;
     hasInitializedTrackRef.current = true;
@@ -124,7 +129,7 @@ export function StudySlidesCarousel({ nav }: Readonly<{ nav: StudyNavigationMode
   useLayoutEffect(() => {
     if (slideWidth <= 0 || !hasInitializedTrackRef.current) return;
 
-    const targetX = -nav.currentSlideIndex * slideWidth;
+    const targetX = -nav.currentSlideIndex * slideStride;
     const widthChanged = previousSlideWidthRef.current !== slideWidth;
     const slideChanged = previousSlideIndexRef.current !== nav.currentSlideIndex;
 
@@ -142,7 +147,7 @@ export function StudySlidesCarousel({ nav }: Readonly<{ nav: StudyNavigationMode
     previousSlideWidthRef.current = slideWidth;
     previousSlideIndexRef.current = nav.currentSlideIndex;
     animateTrackToSlide(fromSlideIndex, nav.currentSlideIndex);
-  }, [nav.currentSlideIndex, slideWidth, trackX]);
+  }, [nav.currentSlideIndex, slideStride, slideWidth, trackX]);
 
   useEffect(() => {
     return () => {
@@ -150,12 +155,12 @@ export function StudySlidesCarousel({ nav }: Readonly<{ nav: StudyNavigationMode
     };
   }, []);
 
-  const handleTrackDragEnd = (_event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
+  const handleSwipeEnd = (offsetX: number, velocityX: number) => {
     if (slideWidth <= 0) return;
 
     const swipeDirection = getStudySwipeNavigationDirection({
-      offsetX: info.offset.x,
-      velocityX: info.velocity.x,
+      offsetX,
+      velocityX,
       slideWidth,
     });
 
@@ -172,26 +177,42 @@ export function StudySlidesCarousel({ nav }: Readonly<{ nav: StudyNavigationMode
     animateTrackToSlide(nav.currentSlideIndex, nav.currentSlideIndex);
   };
 
+  const handleTrackDragEnd = (_event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
+    handleSwipeEnd(info.offset.x, info.velocity.x);
+  };
+
+  const summarySlidePointerSwipe = useStudySummarySlidePointerSwipe({
+    enabled: nav.currentSlideIndex === 0 && slideStride > 0,
+    currentSlideIndex: nav.currentSlideIndex,
+    slideStride,
+    lastSlideIndex: nav.lastSlideIndex,
+    trackX,
+    stopTrackAnimation,
+    onSwipeEnd: ({ offsetX, velocityX }) => handleSwipeEnd(offsetX, velocityX),
+  });
+
   const handleSummaryItemSelect = (itemIndex: number) => {
     pendingFocusSlideIndexRef.current = itemIndex + 1;
     nav.handleSelectItem(itemIndex);
   };
 
-  const trackWidth = slideWidth > 0 ? slideWidth * slides.length : `${slides.length * 100}%`;
+  const gapWidth = STUDY_SLIDES_GAP_PX * (slides.length - 1);
+
+  const trackWidth =
+    slideWidth > 0 ? slideWidth * slides.length + gapWidth : `${slides.length * 100}%`;
   const individualSlideWidth = slideWidth > 0 ? slideWidth : `${100 / slides.length}%`;
 
   return (
     <div
       ref={viewportRef}
-      className="relative flex flex-1 min-h-0 min-w-0 w-full overflow-hidden touch-pan-y"
+      className={cn('relative flex flex-1 min-h-0 min-w-0 w-full overflow-hidden')}
     >
-      <Panel className="h-full min-h-0 w-full p-2 overflow-hidden">
+      <div className="h-full min-h-0 w-full overflow-hidden">
         <motion.div
-          className="absolute inset-y-0 left-0 flex min-h-0 will-change-transform overflow-hidden"
+          className="absolute inset-y-0 left-0 flex min-h-0 overflow-hidden will-change-transform gap-p-spacing-6"
           style={{ x: trackX, width: trackWidth }}
           drag="x"
-          dragConstraints={{ left: -(nav.lastSlideIndex * slideWidth), right: 0 }}
-          dragDirectionLock
+          dragConstraints={{ left: -(nav.lastSlideIndex * slideStride), right: 0 }}
           dragElastic={0.08}
           dragMomentum={false}
           onDragStart={stopTrackAnimation}
@@ -210,26 +231,31 @@ export function StudySlidesCarousel({ nav }: Readonly<{ nav: StudyNavigationMode
                 aria-label={
                   slide.kind === 'summary' ? 'Summary slide' : `Detail slide ${slide.itemIndex + 1}`
                 }
-                className="flex h-full min-h-0 min-w-0 shrink-0 overflow-hidden"
+                className="flex h-full min-h-0 min-w-0 shrink-0 p-1"
                 data-active={isActive ? 'true' : 'false'}
                 data-study-slide-index={slideIndex}
                 inert={!isActive}
                 style={{ width: individualSlideWidth }}
                 tabIndex={isActive ? -1 : undefined}
+                {...(slide.kind === 'summary' && isActive ? summarySlidePointerSwipe : {})}
               >
                 {slide.kind === 'summary' ? (
-                  <LetterStudySummarySlide
-                    items={nav.items}
-                    onSelectItem={handleSummaryItemSelect}
-                  />
+                  <Panel className="h-full min-h-0 w-full overflow-hidden">
+                    <LetterStudySummarySlide
+                      items={nav.items}
+                      onSelectItem={handleSummaryItemSelect}
+                    />
+                  </Panel>
                 ) : (
-                  <LetterStudyDetailSlide item={slide.item} />
+                  <Panel className="h-full min-h-0 w-full overflow-hidden">
+                    <LetterStudyDetailSlide item={slide.item} />
+                  </Panel>
                 )}
               </section>
             );
           })}
         </motion.div>
-      </Panel>
+      </div>
     </div>
   );
 }

--- a/apps/game-client/src/ui/experiences/study/components/summary/letter-study-summary-item-preview.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/summary/letter-study-summary-item-preview.tsx
@@ -13,8 +13,6 @@ export function LetterStudySummaryItemPreview({
       <div
         className={cn(
           'flex h-full w-full max-w-full items-center justify-center @container',
-
-          'group-active:scale-95',
           'flex-col gap-p-spacing-1',
         )}
       >

--- a/apps/game-client/src/ui/experiences/study/components/summary/letter-study-summary-item-preview.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/summary/letter-study-summary-item-preview.tsx
@@ -12,21 +12,33 @@ export function LetterStudySummaryItemPreview({
     <StudySummaryItemButton label={`Open ${item.targetScript}`} onClick={onClick}>
       <div
         className={cn(
-          'flex h-full aspect-square max-w-full items-center justify-center @container',
-          'text-s-color-panel-action-ghost-content',
-          'group-hover:bg-s-color-panel-action-ghost-hover-bg',
-          'group-hover:text-s-color-panel-action-ghost-hover-content',
-          'group-active:bg-s-color-panel-action-ghost-hover-bg',
-          'group-active:text-s-color-panel-action-ghost-hover-content',
+          'flex h-full w-full max-w-full items-center justify-center @container',
+
           'active:scale-95',
+          'flex-col gap-p-spacing-1',
         )}
       >
         <div
           className={cn(
             'font-georgian text-2xl @[50px]:text-4xl @[100px]:text-5xl @[150px]:text-6xl',
+            'text-s-color-panel-action-ghost-content-primary',
+            'group-hover:text-s-color-panel-action-ghost-hover-content-primary',
+            'group-active:text-s-color-panel-action-ghost-hover-content-primary',
           )}
         >
           {item.targetScript}
+        </div>
+        <div
+          className={cn(
+            'flex items-center justify-center gap-1 text-lg',
+            'text-s-color-panel-action-ghost-content-secondary',
+            'group-hover:text-s-color-panel-action-ghost-hover-content-secondary',
+            'group-active:text-s-color-panel-action-ghost-hover-content-secondary',
+          )}
+        >
+          <span className="text-s-color-panel-content-transliteration-bracket">[</span>
+          <span className="flex">{item.transliteration}</span>
+          <span className="text-s-color-panel-content-transliteration-bracket">]</span>
         </div>
       </div>
     </StudySummaryItemButton>

--- a/apps/game-client/src/ui/experiences/study/components/summary/letter-study-summary-item-preview.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/summary/letter-study-summary-item-preview.tsx
@@ -14,7 +14,7 @@ export function LetterStudySummaryItemPreview({
         className={cn(
           'flex h-full w-full max-w-full items-center justify-center @container',
 
-          'active:scale-95',
+          'group-active:scale-95',
           'flex-col gap-p-spacing-1',
         )}
       >

--- a/apps/game-client/src/ui/experiences/study/components/summary/letter-study-summary-slide.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/summary/letter-study-summary-slide.tsx
@@ -4,8 +4,6 @@ import type { LetterItem } from '@game-client/learning-content/library/library';
 import { LetterStudySummaryItemPreview } from '@game-client/ui/experiences/study/components/summary/letter-study-summary-item-preview';
 import { StudySummaryGrid } from '@game-client/ui/experiences/study/components/summary/study-summary-grid';
 
-const MAX_SUMMARY_ITEMS_COUNT = 42;
-
 interface LetterStudySummarySlideProps {
   items: ReadonlyArray<LetterItem>;
   onSelectItem: (itemIndex: number) => void;
@@ -15,17 +13,20 @@ export function LetterStudySummarySlide({
   items,
   onSelectItem,
 }: Readonly<LetterStudySummarySlideProps>) {
-  const boundedItems = items.slice(0, MAX_SUMMARY_ITEMS_COUNT);
-
   return (
-    <StudySummaryGrid itemsCount={boundedItems.length}>
-      {boundedItems.map((item, index) => (
-        <LetterStudySummaryItemPreview
-          key={item.id}
-          item={item}
-          onClick={() => onSelectItem(index)}
-        />
-      ))}
-    </StudySummaryGrid>
+    <div className="flex min-h-0 flex-1 flex-col touch-pan-y gap-p-spacing-2 overflow-x-hidden overflow-y-auto p-p-spacing-2">
+      <div className="flex flex-col gap-1 p-p-spacing-4 text-center text-s-color-panel-content-secondary">
+        TAP ANY ITEM FOR DETAILS
+      </div>
+      <StudySummaryGrid>
+        {items.map((item, index) => (
+          <LetterStudySummaryItemPreview
+            key={item.id}
+            item={item}
+            onClick={() => onSelectItem(index)}
+          />
+        ))}
+      </StudySummaryGrid>
+    </div>
   );
 }

--- a/apps/game-client/src/ui/experiences/study/components/summary/study-summary-grid.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/summary/study-summary-grid.tsx
@@ -3,47 +3,25 @@
 import { cn } from '@kartuli/ui/utils/cn';
 import type { ReactNode } from 'react';
 
-const MAX_ITEMS_COUNT = 42;
-
-const SUMMARY_GRID_BUCKETS = [
-  { maxItems: 1, className: 'gap-4 grid-cols-1 grid-rows-1' },
-  { maxItems: 2, className: 'gap-4 grid-cols-1 grid-rows-2' },
-  { maxItems: 4, className: 'gap-4 grid-cols-2 grid-rows-2' },
-  { maxItems: 6, className: 'gap-4 grid-cols-2 grid-rows-3' },
-  { maxItems: 9, className: 'gap-4 grid-cols-3 grid-rows-3' },
-  { maxItems: 12, className: 'gap-4 grid-cols-3 grid-rows-4' },
-  { maxItems: 15, className: 'gap-2 grid-cols-3 grid-rows-5' },
-  { maxItems: 16, className: 'gap-2 grid-cols-4 grid-rows-4' },
-  { maxItems: 20, className: 'gap-2 grid-cols-4 grid-rows-5' },
-  { maxItems: 24, className: 'gap-2 grid-cols-4 grid-rows-6' },
-  { maxItems: 25, className: 'gap-2 grid-cols-5 grid-rows-5' },
-  { maxItems: 30, className: 'gap-2 grid-cols-5 grid-rows-6' },
-  { maxItems: 35, className: 'gap-1 grid-cols-5 grid-rows-7' },
-  { maxItems: 36, className: 'gap-2 grid-cols-6 grid-rows-6' },
-  { maxItems: 40, className: 'gap-1 grid-cols-6 grid-rows-7' },
-  { maxItems: MAX_ITEMS_COUNT, className: 'gap-1 grid-cols-6 grid-rows-7' },
-] as const;
-
-function getSummaryGridClassName(itemsCount: number) {
-  const bounded = Math.max(0, Math.min(itemsCount, MAX_ITEMS_COUNT));
-  return (
-    SUMMARY_GRID_BUCKETS.find((bucket) => bounded <= bucket.maxItems)?.className ??
-    SUMMARY_GRID_BUCKETS.at(-1)?.className ??
-    ''
-  );
-}
-
 interface StudySummaryGridProps {
   children: ReactNode;
-  itemsCount: number;
 }
 
-export function StudySummaryGrid({ children, itemsCount }: Readonly<StudySummaryGridProps>) {
+export function StudySummaryGrid({ children }: Readonly<StudySummaryGridProps>) {
   return (
     <div
       className={cn(
-        'p-p-spacing-2 grid h-full w-full min-h-0 min-w-0 place-content-center place-self-center gap-1 overflow-hidden',
-        getSummaryGridClassName(itemsCount),
+        //
+        'p-p-spacing-2',
+        'grid',
+        'grid-cols-2',
+        'h-full',
+        'w-full',
+        'min-h-0',
+        'min-w-0',
+        'items-start',
+        'gap-p-spacing-4',
+        'overflow-x-hidden',
       )}
     >
       {children}

--- a/apps/game-client/src/ui/experiences/study/components/summary/study-summary-grid.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/summary/study-summary-grid.tsx
@@ -11,7 +11,6 @@ export function StudySummaryGrid({ children }: Readonly<StudySummaryGridProps>) 
   return (
     <div
       className={cn(
-        //
         'p-p-spacing-2',
         'grid',
         'grid-cols-2',

--- a/apps/game-client/src/ui/experiences/study/components/summary/study-summary-grid.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/summary/study-summary-grid.tsx
@@ -14,7 +14,6 @@ export function StudySummaryGrid({ children }: Readonly<StudySummaryGridProps>) 
         'p-p-spacing-2',
         'grid',
         'grid-cols-2',
-        'h-full',
         'w-full',
         'min-h-0',
         'min-w-0',

--- a/apps/game-client/src/ui/experiences/study/components/summary/study-summary-item-button.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/summary/study-summary-item-button.tsx
@@ -22,9 +22,14 @@ export function StudySummaryItemButton({
       aria-label={label}
       onClick={onClick}
       className={cn(
-        'group flex min-h-0 min-w-0 cursor-pointer items-center justify-center rounded-p-radius-1 outline-none',
+        'group flex min-h-0 min-w-0 cursor-pointer touch-pan-y items-center justify-center rounded-p-radius-1 outline-none',
         'focus-visible:ring-(length:--s-width-focus-ring)',
         'focus-visible:ring-s-color-panel-action-ghost-ring',
+        'hover:bg-s-color-panel-action-ghost-hover-bg',
+        'active:bg-s-color-panel-action-ghost-hover-bg',
+        'rounded-p-radius-3',
+        'overflow-hidden',
+        'h-30',
         className,
       )}
     >

--- a/apps/game-client/src/ui/experiences/study/components/summary/study-summary-item-button.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/summary/study-summary-item-button.tsx
@@ -30,6 +30,7 @@ export function StudySummaryItemButton({
         'rounded-p-radius-3',
         'overflow-hidden',
         'h-30',
+        'active:scale-95',
         className,
       )}
     >

--- a/apps/game-client/src/ui/experiences/translit/components/translit-input.stories.tsx
+++ b/apps/game-client/src/ui/experiences/translit/components/translit-input.stories.tsx
@@ -18,7 +18,7 @@ function TranslitInputStoryRender(args: ComponentProps<typeof TranslitInput>) {
   return (
     <Panel className="h-[20rem]">
       <PanelHeader context="Source" title="Georgian" variant="default" />
-      <PanelSection className={cn('h-full', 'px-4', 'py-4')}>
+      <PanelSection className={cn('h-full')}>
         <TranslitInput
           {...args}
           value={value}

--- a/apps/game-client/src/ui/experiences/translit/components/translit-panels.stories.tsx
+++ b/apps/game-client/src/ui/experiences/translit/components/translit-panels.stories.tsx
@@ -45,7 +45,7 @@ function TranslitPanelsPreview() {
               }
               variant="default"
             />
-            <PanelSection className={cn('h-full', 'px-4', 'py-4')}>
+            <PanelSection className={cn('h-full')}>
               <TranslitInput
                 ariaLabelledBy={`${inputContextId} ${inputTitleId}`}
                 className="text-2xl font-georgian"

--- a/packages/tailwind-config/shared-styles.css
+++ b/packages/tailwind-config/shared-styles.css
@@ -337,12 +337,20 @@
     --s-color-panel-content-transliteration-bracket
   );
   --color-s-color-panel-action-ghost-bg: var(--s-color-panel-action-ghost-bg);
-  --color-s-color-panel-action-ghost-content-primary: var(--s-color-panel-action-ghost-content-primary);
-  --color-s-color-panel-action-ghost-content-secondary: var(--s-color-panel-action-ghost-content-secondary);
+  --color-s-color-panel-action-ghost-content-primary: var(
+    --s-color-panel-action-ghost-content-primary
+  );
+  --color-s-color-panel-action-ghost-content-secondary: var(
+    --s-color-panel-action-ghost-content-secondary
+  );
   --color-s-color-panel-action-ghost-ring: var(--s-color-panel-action-ghost-ring);
   --color-s-color-panel-action-ghost-hover-bg: var(--s-color-panel-action-ghost-hover-bg);
-  --color-s-color-panel-action-ghost-hover-content-primary: var(--s-color-panel-action-ghost-hover-content-primary);
-  --color-s-color-panel-action-ghost-hover-content-secondary: var(--s-color-panel-action-ghost-hover-content-secondary);
+  --color-s-color-panel-action-ghost-hover-content-primary: var(
+    --s-color-panel-action-ghost-hover-content-primary
+  );
+  --color-s-color-panel-action-ghost-hover-content-secondary: var(
+    --s-color-panel-action-ghost-hover-content-secondary
+  );
 
   /* panel header */
   --color-s-color-panel-header-bg: var(--s-color-panel-header-bg);

--- a/packages/tailwind-config/shared-styles.css
+++ b/packages/tailwind-config/shared-styles.css
@@ -52,7 +52,7 @@
   --p-spacing-3: 12px;
   --p-spacing-4: 16px;
   --p-spacing-5: 20px;
-  --p-spacing-6: 24px;
+  --p-spacing-6: 64px;
 
   /* Primitives: radius */
   --p-radius-none: 0px;
@@ -124,7 +124,8 @@
 
   /* panel */
   --s-color-panel-bg: var(--p-color-neutral-50);
-  --s-color-panel-border: transparent;
+  /* Match panel fill so rounded corners do not reveal the shell/detail surface behind the card */
+  --s-color-panel-border: var(--s-color-panel-bg);
   --s-color-panel-border-hover: var(--p-color-brand-600);
   --s-width-panel-border: 3px;
 
@@ -137,7 +138,7 @@
   /* panel header */
   --s-color-panel-header-bg: var(--p-color-neutral-50);
   --s-color-panel-header-content-primary: var(--p-color-brand-600);
-  --s-color-panel-header-content-secondary: var(--p-color-neutral-500);
+  --s-color-panel-header-content-secondary: var(--p-color-neutral-700);
   --s-color-panel-header-border: var(--p-color-brand-600);
 
   /* panel header inverted */
@@ -157,10 +158,12 @@
 
   /* panel action ghost */
   --s-color-panel-action-ghost-bg: transparent;
-  --s-color-panel-action-ghost-content: var(--p-color-neutral-500);
+  --s-color-panel-action-ghost-content-primary: var(--p-color-neutral-500);
+  --s-color-panel-action-ghost-content-secondary: var(--p-color-neutral-500);
   --s-color-panel-action-ghost-ring: var(--p-color-neutral-500);
   --s-color-panel-action-ghost-hover-bg: var(--p-color-neutral-500);
-  --s-color-panel-action-ghost-hover-content: var(--p-color-neutral-50);
+  --s-color-panel-action-ghost-hover-content-primary: var(--p-color-neutral-50);
+  --s-color-panel-action-ghost-hover-content-secondary: var(--p-color-neutral-200);
 
   /* panel control focus */
   --s-color-panel-control-ring: var(--p-color-neutral-500);
@@ -334,10 +337,12 @@
     --s-color-panel-content-transliteration-bracket
   );
   --color-s-color-panel-action-ghost-bg: var(--s-color-panel-action-ghost-bg);
-  --color-s-color-panel-action-ghost-content: var(--s-color-panel-action-ghost-content);
+  --color-s-color-panel-action-ghost-content-primary: var(--s-color-panel-action-ghost-content-primary);
+  --color-s-color-panel-action-ghost-content-secondary: var(--s-color-panel-action-ghost-content-secondary);
   --color-s-color-panel-action-ghost-ring: var(--s-color-panel-action-ghost-ring);
   --color-s-color-panel-action-ghost-hover-bg: var(--s-color-panel-action-ghost-hover-bg);
-  --color-s-color-panel-action-ghost-hover-content: var(--s-color-panel-action-ghost-hover-content);
+  --color-s-color-panel-action-ghost-hover-content-primary: var(--s-color-panel-action-ghost-hover-content-primary);
+  --color-s-color-panel-action-ghost-hover-content-secondary: var(--s-color-panel-action-ghost-hover-content-secondary);
 
   /* panel header */
   --color-s-color-panel-header-bg: var(--s-color-panel-header-bg);

--- a/turbo.json
+++ b/turbo.json
@@ -41,27 +41,11 @@
     },
     "lint": {
       "cache": true,
-      "inputs": [
-        "**/*.ts",
-        "**/*.tsx",
-        "**/*.js",
-        "**/*.jsx",
-        "**/*.json",
-        "biome.json",
-        "pnpm-lock.yaml"
-      ]
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/biome.json", "$TURBO_ROOT$/biome.root.json"]
     },
     "lint:all": {
       "cache": true,
-      "inputs": [
-        "**/*.ts",
-        "**/*.tsx",
-        "**/*.js",
-        "**/*.jsx",
-        "**/*.json",
-        "biome.json",
-        "pnpm-lock.yaml"
-      ]
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/biome.json", "$TURBO_ROOT$/biome.root.json"]
     },
     "typecheck": {
       "dependsOn": ["^typecheck"],


### PR DESCRIPTION
## Description

Improves the letter study summary experience and related panel styling across the game client.

**Study summary**
- Replaces the fixed bucket-based summary grid (capped at 42 items) with a scrollable two-column layout that shows all items.
- Adds a “TAP ANY ITEM FOR DETAILS” hint and richer summary item previews (Georgian script + transliteration with hover/active states).
- Updates ghost action design tokens to separate primary and secondary content colors.

**Slide carousel & gestures**
- Adds pointer gesture handling that distinguishes horizontal swipes (carousel navigation) from vertical movement (summary scrolling), so the summary slide can scroll without fighting horizontal drag.
- Accounts for slide gap spacing (`--p-spacing-6` → 64px) in track positioning, drag constraints, and animations.
- Wraps each slide in its own `Panel`; moves the outer panel wrapper out of the carousel viewport.

**Panel & explore**
- Refines base `Panel` styling (larger radius, stronger shadow, no default border).
- Introduces `PanelLinkHoverFrame` for hover borders on link cards; applies the pattern on alphabet explore cards.
- Tweaks study navigation/layout spacing and transliteration color on the detail slide.

**Shared tokens**
- Aligns panel border color with panel background to avoid corner bleed.
- Darkens panel header secondary text and splits ghost action content tokens into primary/secondary variants.

---

## Linked Issues

Closes #

---

## Type

- [x] `feat` - New feature
- [ ] `chore` - Infrastructure, setup tasks, non-feature work
- [ ] `fix` - Bug fix
- [ ] `docs` - Documentation changes
- [ ] `test` - Testing-related changes

---

## Scope

- [x] `game-client` - Game client application
- [ ] `backoffice-client` - Backoffice client application
- [ ] `ui` - UI package
- [ ] `storybook` - Storybook tool
- [ ] `e2e` - E2E testing
- [x] `global` - Shared packages or general repository tasks

---

## Screenshots (Optional)

N/A — visual polish; screenshots recommended for summary grid, summary item hover states, and alphabet explore card hover.

---

## Preview Links (Optional)

N/A

---

## Testing Notes

- [x] Tests pass locally
- [x] Linting passes

Verify on a letter study session:
- Summary slide shows all letters in a scrollable two-column grid with the tap hint.
- Vertical scroll works on the summary slide; horizontal swipe still advances to detail slides.
- Summary item buttons show transliteration and respond to hover/active/focus.
- Carousel slide transitions respect the wider gap between slides.
- Alphabet explore cards show hover border via `PanelLinkHoverFrame`.
- Unit tests cover gesture classification and track offset clamping (`study-slide-pointer-swipe.test.ts`).

---

## Documentation Changes (if applicable)

- [ ] Added or updated documentation files
- [ ] Updated cross-references in other docs (if files were renamed/moved)
- [ ] Verified all internal links still work
- [x] N/A - No documentation changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Swipe gesture support on study summary slides for smoother navigation.
  - Hover highlight frame added to panels for clearer interactivity.
  - Summary view now shows all items (no truncation).

- UI Improvements
  - Increased shadow depth on panels and action buttons.
  - Consistent spacing and padding updates across panels and navigation.
  - Study layout refined (reduced gaps, full-height containers, two-column summary grid).
  - Clearer transliteration text colors.
  - Updated summary item previews and buttons for better touch and focus states.

- Tests
  - Added unit tests for swipe gesture classification and track clamping.

- Chores
  - Optimized lint task caching configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->