### PR TITLE
feat(game-client): localize study experience UI strings

### DIFF
--- a/apps/game-client/setupTests.ts
+++ b/apps/game-client/setupTests.ts
@@ -1,0 +1,1 @@
+import '@game-client/i18n/i18n-config';

--- a/apps/game-client/src/i18n/resources/messages/en/study.ts
+++ b/apps/game-client/src/i18n/resources/messages/en/study.ts
@@ -1,0 +1,16 @@
+export default {
+  nav: {
+    previous: 'Previous',
+    prev_short: 'Prev',
+    next: 'Next',
+    summary: 'Summary',
+  },
+  play_now: 'Play now',
+  status: {
+    letters: 'letters',
+  },
+  summary: {
+    tap_hint: 'TAP ANY ITEM FOR DETAILS',
+    open_item: 'Open {{letter}}',
+  },
+} as const;

--- a/apps/game-client/src/i18n/resources/messages/ru/study.ts
+++ b/apps/game-client/src/i18n/resources/messages/ru/study.ts
@@ -1,0 +1,16 @@
+export default {
+  nav: {
+    previous: 'Назад',
+    prev_short: 'Назад',
+    next: 'Вперёд',
+    summary: 'Главная',
+  },
+  play_now: 'Играть',
+  status: {
+    letters: 'букв',
+  },
+  summary: {
+    tap_hint: 'НАЖМИТЕ НА ЛЮБОЙ ЭЛЕМЕНТ',
+    open_item: 'Открыть {{letter}}',
+  },
+} as const;

--- a/apps/game-client/src/i18n/resources/resources-en.ts
+++ b/apps/game-client/src/i18n/resources/resources-en.ts
@@ -4,6 +4,7 @@ import enHome from '@game-client/i18n/resources/messages/en/home';
 import enMetadata from '@game-client/i18n/resources/messages/en/metadata';
 import enNotFound from '@game-client/i18n/resources/messages/en/not-found';
 import enSettings from '@game-client/i18n/resources/messages/en/settings';
+import enStudy from '@game-client/i18n/resources/messages/en/study';
 import enTranslit from '@game-client/i18n/resources/messages/en/translit';
 
 export const enResources = {
@@ -13,5 +14,6 @@ export const enResources = {
   metadata: enMetadata,
   notFound: enNotFound,
   settings: enSettings,
+  study: enStudy,
   translit: enTranslit,
 } as const;

--- a/apps/game-client/src/i18n/resources/resources-ru.ts
+++ b/apps/game-client/src/i18n/resources/resources-ru.ts
@@ -4,6 +4,7 @@ import ruHome from '@game-client/i18n/resources/messages/ru/home';
 import ruMetadata from '@game-client/i18n/resources/messages/ru/metadata';
 import ruNotFound from '@game-client/i18n/resources/messages/ru/not-found';
 import ruSettings from '@game-client/i18n/resources/messages/ru/settings';
+import ruStudy from '@game-client/i18n/resources/messages/ru/study';
 import ruTranslit from '@game-client/i18n/resources/messages/ru/translit';
 import type { SameKeysAsReferenceResources } from '@game-client/i18n/resources/same-keys-as-reference-resources';
 
@@ -14,5 +15,6 @@ export const ruResources: SameKeysAsReferenceResources = {
   metadata: ruMetadata,
   notFound: ruNotFound,
   settings: ruSettings,
+  study: ruStudy,
   translit: ruTranslit,
 };

--- a/apps/game-client/src/ui/experiences/study/components/study-navigation.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/study-navigation.tsx
@@ -97,7 +97,6 @@ export function MobileInfoBar(props: Readonly<StudyNavigationModel>) {
         <StudyNavigationButton
           className="w-full"
           label={t('nav.next')}
-          visualLabel={t('nav.next')}
           icon={PiCaretRight}
           disabled={!canGoNext}
           onClick={handleNext}

--- a/apps/game-client/src/ui/experiences/study/components/study-navigation.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/study-navigation.tsx
@@ -3,6 +3,7 @@
 import { StudyNavigationButton } from '@game-client/ui/experiences/study/components/study-navigation-button';
 import type { StudyNavigationModel } from '@game-client/ui/experiences/study/components/study-screen.types';
 import { StudyStatusPill } from '@game-client/ui/experiences/study/components/study-status-pill';
+import { useTranslation } from 'react-i18next';
 import { PiCaretLeft, PiCaretRight, PiHouseLight } from 'react-icons/pi';
 
 export function NavigationBar(props: Readonly<StudyNavigationModel>) {
@@ -16,13 +17,14 @@ export function NavigationBar(props: Readonly<StudyNavigationModel>) {
     handleNext,
     handleGoToSummary,
   } = props;
+  const { t } = useTranslation('study');
 
   return (
     <div className="hidden w-full grid-cols-[minmax(0,1fr)_auto_auto_minmax(0,1fr)] items-center gap-3 md:grid px-1">
       <div className="flex min-w-0 items-center justify-center">
         <StudyNavigationButton
           className="w-full min-w-0"
-          label="Previous"
+          label={t('nav.previous')}
           icon={PiCaretLeft}
           disabled={!canGoPrevious}
           onClick={handlePrevious}
@@ -30,7 +32,7 @@ export function NavigationBar(props: Readonly<StudyNavigationModel>) {
       </div>
       <div className="flex min-w-0 items-center justify-center">
         <StudyNavigationButton
-          label="Summary"
+          label={t('nav.summary')}
           icon={PiHouseLight}
           disabled={!canGoToSummary}
           onClick={handleGoToSummary}
@@ -43,7 +45,7 @@ export function NavigationBar(props: Readonly<StudyNavigationModel>) {
       <div className="flex min-w-0 items-center justify-center">
         <StudyNavigationButton
           className="w-full min-w-0"
-          label="Next"
+          label={t('nav.next')}
           icon={PiCaretRight}
           disabled={!canGoNext}
           onClick={handleNext}
@@ -65,14 +67,15 @@ export function MobileInfoBar(props: Readonly<StudyNavigationModel>) {
     handleNext,
     handleGoToSummary,
   } = props;
+  const { t } = useTranslation('study');
 
   return (
     <div className="grid w-full grid-cols-[minmax(0,1fr)_auto_auto_minmax(0,1fr)] items-center gap-2 md:hidden px-1">
       <div className="flex min-w-0 items-center justify-center">
         <StudyNavigationButton
           className="w-full"
-          label="Previous"
-          visualLabel="Prev"
+          label={t('nav.previous')}
+          visualLabel={t('nav.prev_short')}
           icon={PiCaretLeft}
           disabled={!canGoPrevious}
           onClick={handlePrevious}
@@ -80,7 +83,7 @@ export function MobileInfoBar(props: Readonly<StudyNavigationModel>) {
       </div>
       <div className="flex min-w-0 items-center justify-center">
         <StudyNavigationButton
-          label="Summary"
+          label={t('nav.summary')}
           icon={PiHouseLight}
           disabled={!canGoToSummary}
           onClick={handleGoToSummary}
@@ -93,8 +96,8 @@ export function MobileInfoBar(props: Readonly<StudyNavigationModel>) {
       <div className="flex min-w-0 items-center justify-center">
         <StudyNavigationButton
           className="w-full"
-          label="Next"
-          visualLabel="Next"
+          label={t('nav.next')}
+          visualLabel={t('nav.next')}
           icon={PiCaretRight}
           disabled={!canGoNext}
           onClick={handleNext}

--- a/apps/game-client/src/ui/experiences/study/components/study-screen-layout.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/study-screen-layout.tsx
@@ -7,16 +7,18 @@ import {
 } from '@game-client/ui/experiences/study/components/study-navigation';
 import type { StudyNavigationModel } from '@game-client/ui/experiences/study/components/study-screen.types';
 import { StudySlidesCarousel } from '@game-client/ui/experiences/study/components/study-slides-carousel';
+import { useTranslation } from 'react-i18next';
 import { PiPlayFill } from 'react-icons/pi';
 
 export function StudyScreenLayout({ nav }: Readonly<{ nav: StudyNavigationModel }>) {
+  const { t } = useTranslation('study');
   return (
     <div className="flex flex-1 min-h-0 min-w-0 flex-col gap-2 h-full max-w-[600px] w-full mx-auto">
       <NavigationBar {...nav} />
       <StudySlidesCarousel nav={nav} />
       <MobileInfoBar {...nav} />
       <div className="flex w-full px-1">
-        <StudyCtaButton label="Play now" icon={PiPlayFill} />
+        <StudyCtaButton label={t('play_now')} icon={PiPlayFill} />
       </div>
     </div>
   );

--- a/apps/game-client/src/ui/experiences/study/components/study-status-pill.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/study-status-pill.tsx
@@ -2,6 +2,7 @@
 
 import type { StudyNavigationState } from '@game-client/ui/experiences/study/components/study-screen.types';
 import { cn } from '@kartuli/ui/utils/cn';
+import { useTranslation } from 'react-i18next';
 
 export interface StudyStatusPillProps
   extends Pick<StudyNavigationState, 'currentItem' | 'totalItems'> {
@@ -13,6 +14,7 @@ export function StudyStatusPill({
   currentItem,
   totalItems,
 }: Readonly<StudyStatusPillProps>) {
+  const { t } = useTranslation('study');
   return (
     <div
       className={cn(
@@ -34,7 +36,7 @@ export function StudyStatusPill({
     >
       {currentItem === 'summary' ? (
         <div className="flex items-center justify-center gap-1 text-xs">
-          <span className="font-bold">{totalItems}</span> letters
+          <span className="font-bold">{totalItems}</span> {t('status.letters')}
         </div>
       ) : (
         <div className="flex items-center justify-center gap-1 text-base">

--- a/apps/game-client/src/ui/experiences/study/components/summary/letter-study-summary-item-preview.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/summary/letter-study-summary-item-preview.tsx
@@ -3,13 +3,18 @@
 import type { LetterItem } from '@game-client/learning-content/library/library';
 import { StudySummaryItemButton } from '@game-client/ui/experiences/study/components/summary/study-summary-item-button';
 import { cn } from '@kartuli/ui/utils/cn';
+import { useTranslation } from 'react-i18next';
 
 export function LetterStudySummaryItemPreview({
   item,
   onClick,
 }: Readonly<{ item: LetterItem; onClick: () => void }>) {
+  const { t } = useTranslation('study');
   return (
-    <StudySummaryItemButton label={`Open ${item.targetScript}`} onClick={onClick}>
+    <StudySummaryItemButton
+      label={t('summary.open_item', { letter: item.targetScript })}
+      onClick={onClick}
+    >
       <div
         className={cn(
           'flex h-full w-full max-w-full items-center justify-center @container',

--- a/apps/game-client/src/ui/experiences/study/components/summary/letter-study-summary-slide.tsx
+++ b/apps/game-client/src/ui/experiences/study/components/summary/letter-study-summary-slide.tsx
@@ -3,6 +3,7 @@
 import type { LetterItem } from '@game-client/learning-content/library/library';
 import { LetterStudySummaryItemPreview } from '@game-client/ui/experiences/study/components/summary/letter-study-summary-item-preview';
 import { StudySummaryGrid } from '@game-client/ui/experiences/study/components/summary/study-summary-grid';
+import { useTranslation } from 'react-i18next';
 
 interface LetterStudySummarySlideProps {
   items: ReadonlyArray<LetterItem>;
@@ -13,10 +14,11 @@ export function LetterStudySummarySlide({
   items,
   onSelectItem,
 }: Readonly<LetterStudySummarySlideProps>) {
+  const { t } = useTranslation('study');
   return (
     <div className="flex min-h-0 flex-1 flex-col touch-pan-y gap-p-spacing-2 overflow-x-hidden overflow-y-auto p-p-spacing-2">
       <div className="flex flex-col gap-1 p-p-spacing-4 text-center text-s-color-panel-content-secondary">
-        TAP ANY ITEM FOR DETAILS
+        {t('summary.tap_hint')}
       </div>
       <StudySummaryGrid>
         {items.map((item, index) => (


### PR DESCRIPTION
Description:
<!-- 
Thank you for contributing to Kartuli!
Please fill out this template to help reviewers understand your changes.

IMPORTANT: Ensure your PR title follows conventional commit format:
Examples:
  - feat(game-client): add user authentication
  - fix(ui): resolve button alignment issue
  - docs: update contributing guidelines
  - chore(e2e): upgrade testing dependencies
-->

## Description

Adds a dedicated `study` i18n namespace (English and Russian) and replaces hardcoded English copy in the letter study flow with `useTranslation('study')`.

**i18n**
- New `messages/en/study.ts` and `messages/ru/study.ts` for navigation labels, CTA, status text, and summary hints (including `open_item` with `{{letter}}` interpolation).
- Registers `study` in `resources-en.ts` and `resources-ru.ts`.

**UI**
- `study-navigation.tsx` — Previous / Prev / Next / Summary.
- `study-screen-layout.tsx` — Play now CTA.
- `study-status-pill.tsx` — “letters” count label on the summary slide.
- `letter-study-summary-slide.tsx` — tap hint.
- `letter-study-summary-item-preview.tsx` — per-letter “Open …” button label.

**Tests**
- `setupTests.ts` imports `@game-client/i18n/i18n-config` so components using `useTranslation` behave correctly in Vitest.

---

## Linked Issues

Closes #

---

## Type

- [x] `feat` - New feature
- [ ] `chore` - Infrastructure, setup tasks, non-feature work
- [ ] `fix` - Bug fix
- [ ] `docs` - Documentation changes
- [ ] `test` - Testing-related changes

---

## Scope

- [x] `game-client` - Game client application
- [ ] `backoffice-client` - Backoffice client application
- [ ] `ui` - UI package
- [ ] `storybook` - Storybook tool
- [ ] `e2e` - E2E testing
- [ ] `global` - Shared packages or general repository tasks

---

## Screenshots (Optional)

N/A — copy-only change; verify in `/ru/` locale on study screens (navigation, summary grid, status pill, Play now).

---

## Preview Links (Optional)

N/A

---

## Testing Notes

- [ ] Tests pass locally
- [ ] Linting passes

- Switch locale to Russian and open a letter study session: nav buttons, “Play now”, summary hint, item labels, and “N letters” status should be in Russian.
- Confirm English (`/en/`) still shows the same strings as before.
- Run `pnpm run validate:all`.

---

## Documentation Changes (if applicable)

- [ ] Added or updated documentation files
- [ ] Updated cross-references in other docs (if files were renamed/moved)
- [ ] Verified all internal links still work
- [x] N/A - No documentation changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internationalization support for the study experience
  * Study interface now available in English and Russian
  * Navigation buttons, play call-to-action, status labels, and summary content are now fully localized
  * Test setup updated to initialize translation configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->