### PR TITLE
feat(game-client): use panel UI and radio buttons on settings page

### DIFF
--- a/apps/game-client/src/i18n/resources/messages/en/settings.ts
+++ b/apps/game-client/src/i18n/resources/messages/en/settings.ts
@@ -1,4 +1,5 @@
 export default {
+  app_settings: 'App Settings',
   language_section: 'Language',
   current_language: 'Current language: {{language}}',
   languages: {

--- a/apps/game-client/src/i18n/resources/messages/ru/settings.ts
+++ b/apps/game-client/src/i18n/resources/messages/ru/settings.ts
@@ -1,4 +1,5 @@
 export default {
+  app_settings: 'Настройки приложения',
   language_section: 'Язык',
   current_language: 'Текущий язык: {{language}}',
   languages: {

--- a/apps/game-client/src/ui/components/inputs/radio-button.tsx
+++ b/apps/game-client/src/ui/components/inputs/radio-button.tsx
@@ -1,0 +1,40 @@
+import { cn } from '@kartuli/ui/utils/cn';
+
+interface RadioButtonProps {
+  checked: boolean;
+  label: string;
+  name: string;
+  onChange: () => void;
+  value: string;
+}
+
+export function RadioButton({ checked, label, name, onChange, value }: Readonly<RadioButtonProps>) {
+  return (
+    <label className={cn('flex', 'cursor-pointer', 'items-center', 'gap-p-spacing-3', 'py-2')}>
+      <input
+        type="radio"
+        name={name}
+        value={value}
+        checked={checked}
+        onChange={onChange}
+        className={cn(
+          'size-5',
+          'shrink-0',
+          'appearance-none',
+          'rounded-full',
+          'border-2',
+          'border-s-color-panel-content-primary',
+          'outline-none',
+          'transition-colors',
+          'checked:border-p-color-brand-600',
+          'checked:bg-p-color-brand-600',
+          'checked:shadow-[inset_0_0_0_3px_var(--s-color-panel-bg)]',
+          'cursor-pointer',
+          'focus-visible:ring-(length:--s-width-focus-ring)',
+          'focus-visible:ring-s-color-panel-control-ring',
+        )}
+      />
+      <span className={cn('text-s-color-panel-content-primary', 'font-medium')}>{label}</span>
+    </label>
+  );
+}

--- a/apps/game-client/src/ui/components/inputs/radio-button.tsx
+++ b/apps/game-client/src/ui/components/inputs/radio-button.tsx
@@ -1,21 +1,40 @@
+'use client';
+
 import { cn } from '@kartuli/ui/utils/cn';
 
 interface RadioButtonProps {
   checked: boolean;
+  disabled?: boolean;
   label: string;
   name: string;
   onChange: () => void;
   value: string;
 }
 
-export function RadioButton({ checked, label, name, onChange, value }: Readonly<RadioButtonProps>) {
+export function RadioButton({
+  checked,
+  disabled,
+  label,
+  name,
+  onChange,
+  value,
+}: Readonly<RadioButtonProps>) {
   return (
-    <label className={cn('flex', 'cursor-pointer', 'items-center', 'gap-p-spacing-3', 'py-2')}>
+    <label
+      className={cn(
+        'flex',
+        'items-center',
+        'gap-p-spacing-3',
+        'py-2',
+        disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
+      )}
+    >
       <input
         type="radio"
         name={name}
         value={value}
         checked={checked}
+        disabled={disabled}
         onChange={onChange}
         className={cn(
           'size-5',
@@ -29,9 +48,9 @@ export function RadioButton({ checked, label, name, onChange, value }: Readonly<
           'checked:border-p-color-brand-600',
           'checked:bg-p-color-brand-600',
           'checked:shadow-[inset_0_0_0_3px_var(--s-color-panel-bg)]',
-          'cursor-pointer',
           'focus-visible:ring-(length:--s-width-focus-ring)',
           'focus-visible:ring-s-color-panel-control-ring',
+          disabled ? 'cursor-not-allowed' : 'cursor-pointer',
         )}
       />
       <span className={cn('text-s-color-panel-content-primary', 'font-medium')}>{label}</span>

--- a/apps/game-client/src/ui/experiences/settings/components/settings-client.tsx
+++ b/apps/game-client/src/ui/experiences/settings/components/settings-client.tsx
@@ -12,6 +12,7 @@ import { Panel } from '@game-client/ui/components/panel/panel';
 import { PanelHeader } from '@game-client/ui/components/panel/panel-header';
 import { PanelSection } from '@game-client/ui/components/panel/panel-section';
 import Cookies from 'js-cookie';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 export function SettingsClient() {
@@ -19,14 +20,21 @@ export function SettingsClient() {
   const { i18n } = useTranslation('common');
   const { localizedPathname, navigate } = useNavigation();
   const currentLocale = useCurrentRouteLocale();
+  const [isSwitching, setIsSwitching] = useState(false);
 
   const handleLanguageSwitch = (locale: SupportedLocale) => {
-    if (locale === currentLocale) return;
-    Cookies.set(PREFERRED_LOCALE_KEY, locale, { path: '/' });
+    if (locale === currentLocale || isSwitching) return;
+    setIsSwitching(true);
     const newPath = getLocalizedPathnameForLocale(localizedPathname, locale);
-    i18n.changeLanguage(locale).then(() => {
-      navigate(newPath);
-    });
+    i18n
+      .changeLanguage(locale)
+      .then(() => {
+        Cookies.set(PREFERRED_LOCALE_KEY, locale, { path: '/' });
+        navigate(newPath);
+      })
+      .catch(() => {
+        setIsSwitching(false);
+      });
   };
 
   return (
@@ -43,6 +51,7 @@ export function SettingsClient() {
                 value={locale}
                 label={t(`languages.${locale}`)}
                 checked={locale === currentLocale}
+                disabled={isSwitching}
                 onChange={() => handleLanguageSwitch(locale)}
               />
             ))}

--- a/apps/game-client/src/ui/experiences/settings/components/settings-client.tsx
+++ b/apps/game-client/src/ui/experiences/settings/components/settings-client.tsx
@@ -7,34 +7,21 @@ import {
   supportedLocales,
 } from '@game-client/i18n';
 import { useCurrentRouteLocale, useNavigation } from '@game-client/navigation';
+import { RadioButton } from '@game-client/ui/components/inputs/radio-button';
+import { Panel } from '@game-client/ui/components/panel/panel';
+import { PanelHeader } from '@game-client/ui/components/panel/panel-header';
+import { PanelSection } from '@game-client/ui/components/panel/panel-section';
 import Cookies from 'js-cookie';
 import { useTranslation } from 'react-i18next';
-
-function LanguageSwitchButton({
-  locale,
-  label,
-  onClick,
-}: Readonly<{
-  locale: SupportedLocale;
-  label: string;
-  onClick: (locale: SupportedLocale) => void;
-}>) {
-  return (
-    <button type="button" onClick={() => onClick(locale)} className="border p-2" aria-label={label}>
-      {label}
-    </button>
-  );
-}
 
 export function SettingsClient() {
   const { t } = useTranslation('settings');
   const { i18n } = useTranslation('common');
   const { localizedPathname, navigate } = useNavigation();
   const currentLocale = useCurrentRouteLocale();
-  const currentLanguageLabel = t(`languages.${currentLocale}`);
-  const switchableLocales = supportedLocales.filter((locale) => locale !== currentLocale);
 
   const handleLanguageSwitch = (locale: SupportedLocale) => {
+    if (locale === currentLocale) return;
     Cookies.set(PREFERRED_LOCALE_KEY, locale, { path: '/' });
     const newPath = getLocalizedPathnameForLocale(localizedPathname, locale);
     i18n.changeLanguage(locale).then(() => {
@@ -43,20 +30,25 @@ export function SettingsClient() {
   };
 
   return (
-    <main>
-      <h1>{t('language_section')}</h1>
-      <p>{t('current_language', { language: currentLanguageLabel })}</p>
-      <ul aria-label={t('language_section')}>
-        {switchableLocales.map((locale) => (
-          <li key={locale}>
-            <LanguageSwitchButton
-              locale={locale}
-              label={t(`languages.${locale}`)}
-              onClick={handleLanguageSwitch}
-            />
-          </li>
-        ))}
-      </ul>
+    <main className="flex flex-col h-full">
+      <Panel>
+        <PanelHeader context={t('app_settings')} title={t('language_section')} variant="default" />
+        <PanelSection>
+          <fieldset className="border-none p-0">
+            <legend className="sr-only">{t('language_section')}</legend>
+            {supportedLocales.map((locale) => (
+              <RadioButton
+                key={locale}
+                name="language"
+                value={locale}
+                label={t(`languages.${locale}`)}
+                checked={locale === currentLocale}
+                onChange={() => handleLanguageSwitch(locale)}
+              />
+            ))}
+          </fieldset>
+        </PanelSection>
+      </Panel>
     </main>
   );
 }

--- a/tools/e2e/tests/game-client/pages/settings.spec.ts
+++ b/tools/e2e/tests/game-client/pages/settings.spec.ts
@@ -11,7 +11,7 @@ test.describe('Settings page', () => {
     await page.goto(`${defaultLocaleBase}/settings`);
     await expect(page.getByRole('heading', { name: settingsTitle })).toBeVisible();
     await expect(page.getByText(settings.app_settings)).toBeVisible();
-    await expect(page.getByText(settings.language_section)).toBeVisible();
+    await expect(page.getByText(settings.language_section).first()).toBeVisible();
   });
 
   test('renders language options as radio buttons with current locale selected', async ({

--- a/tools/e2e/tests/game-client/pages/settings.spec.ts
+++ b/tools/e2e/tests/game-client/pages/settings.spec.ts
@@ -5,19 +5,25 @@ import { defaultLocaleBase } from '../../helpers/locale-url';
 
 const settingsTitle = enResources.common.dock.settings;
 const settings = enResources.settings;
-const current_language = settings.current_language.replace('{{language}}', settings.languages.en);
 
 test.describe('Settings page', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(`${defaultLocaleBase}/settings`);
     await expect(page.getByRole('heading', { name: settingsTitle })).toBeVisible();
-    await expect(page.getByRole('heading', { name: settings.language_section })).toBeVisible();
+    await expect(page.getByText(settings.app_settings)).toBeVisible();
+    await expect(page.getByText(settings.language_section)).toBeVisible();
   });
 
-  test('renders current language and the alternate language action', async ({ page }) => {
-    await expect(page.getByText(current_language)).toBeVisible();
-    await expect(page.getByRole('button', { name: settings.languages.ru })).toBeVisible();
-    await expect(page.getByRole('button', { name: settings.languages.en })).toHaveCount(0);
+  test('renders language options as radio buttons with current locale selected', async ({
+    page,
+  }) => {
+    const enRadio = page.getByRole('radio', { name: settings.languages.en });
+    const ruRadio = page.getByRole('radio', { name: settings.languages.ru });
+
+    await expect(enRadio).toBeVisible();
+    await expect(enRadio).toBeChecked();
+    await expect(ruRadio).toBeVisible();
+    await expect(ruRadio).not.toBeChecked();
   });
 
   test('has no a11y violations on initial load', async ({ page }) => {

--- a/tools/e2e/tests/game-client/production/i18n.spec.ts
+++ b/tools/e2e/tests/game-client/production/i18n.spec.ts
@@ -3,19 +3,11 @@ import { ruResources } from '@game-client/i18n/resources/resources-ru';
 import { expect, test } from '@playwright/test';
 
 const EN_DESCRIPTION = enResources.metadata.description;
-const EN_CURRENT_LANGUAGE = enResources.settings.current_language.replace(
-  '{{language}}',
-  enResources.settings.languages.en,
-);
 const EN_SETTINGS_TITLE = enResources.common.dock.settings;
 const EN_LANGUAGE_SECTION = enResources.settings.language_section;
 const EN_SWITCH_TO_RU_LABEL = enResources.settings.languages.ru;
 const EN_ALPHABET_TITLE = enResources.alphabet.title;
 const EN_HOME_HEADING = enResources.home.heading;
-const RU_CURRENT_LANGUAGE = ruResources.settings.current_language.replace(
-  '{{language}}',
-  ruResources.settings.languages.ru,
-);
 const RU_DESCRIPTION = ruResources.metadata.description;
 const RU_SETTINGS_TITLE = ruResources.common.dock.settings;
 const RU_LANGUAGE_SECTION = ruResources.settings.language_section;
@@ -63,17 +55,16 @@ test.describe('Game Client i18n', () => {
 
     await expect(page.locator('html')).toHaveAttribute('lang', 'en');
     await expect(page.getByRole('heading', { name: EN_SETTINGS_TITLE })).toBeVisible();
-    await expect(page.getByRole('heading', { name: EN_LANGUAGE_SECTION })).toBeVisible();
-    await expect(page.getByText(EN_CURRENT_LANGUAGE)).toBeVisible();
-    await expect(page.getByRole('button', { name: EN_SWITCH_TO_RU_LABEL })).toBeVisible();
+    await expect(page.getByText(EN_LANGUAGE_SECTION).first()).toBeVisible();
+    await expect(page.getByRole('radio', { name: EN_SWITCH_TO_RU_LABEL })).toBeVisible();
 
-    await page.getByRole('button', { name: EN_SWITCH_TO_RU_LABEL }).click();
+    await page.getByRole('radio', { name: EN_SWITCH_TO_RU_LABEL }).click();
 
     await expect(page).toHaveURL(/\/ru\/settings\/?$/);
     await expect(page.locator('html')).toHaveAttribute('lang', 'ru');
     await expect(page.getByRole('heading', { name: RU_SETTINGS_TITLE })).toBeVisible();
-    await expect(page.getByRole('heading', { name: RU_LANGUAGE_SECTION })).toBeVisible();
-    await expect(page.getByText(RU_CURRENT_LANGUAGE)).toBeVisible();
+    await expect(page.getByText(RU_LANGUAGE_SECTION).first()).toBeVisible();
+    await expect(page.getByRole('radio', { name: EN_SWITCH_TO_RU_LABEL })).toBeChecked();
   });
 
   test('settings language switcher: from /ru/settings switch to English updates URL, html lang and content', async ({
@@ -83,17 +74,16 @@ test.describe('Game Client i18n', () => {
 
     await expect(page.locator('html')).toHaveAttribute('lang', 'ru');
     await expect(page.getByRole('heading', { name: RU_SETTINGS_TITLE })).toBeVisible();
-    await expect(page.getByRole('heading', { name: RU_LANGUAGE_SECTION })).toBeVisible();
-    await expect(page.getByText(RU_CURRENT_LANGUAGE)).toBeVisible();
-    await expect(page.getByRole('button', { name: RU_SWITCH_TO_EN_LABEL })).toBeVisible();
+    await expect(page.getByText(RU_LANGUAGE_SECTION).first()).toBeVisible();
+    await expect(page.getByRole('radio', { name: RU_SWITCH_TO_EN_LABEL })).toBeVisible();
 
-    await page.getByRole('button', { name: RU_SWITCH_TO_EN_LABEL }).click();
+    await page.getByRole('radio', { name: RU_SWITCH_TO_EN_LABEL }).click();
 
     await expect(page).toHaveURL(/\/en\/settings\/?$/);
     await expect(page.locator('html')).toHaveAttribute('lang', 'en');
     await expect(page.getByRole('heading', { name: EN_SETTINGS_TITLE })).toBeVisible();
-    await expect(page.getByRole('heading', { name: EN_LANGUAGE_SECTION })).toBeVisible();
-    await expect(page.getByText(EN_CURRENT_LANGUAGE)).toBeVisible();
+    await expect(page.getByText(EN_LANGUAGE_SECTION).first()).toBeVisible();
+    await expect(page.getByRole('radio', { name: RU_SWITCH_TO_EN_LABEL })).toBeChecked();
   });
 
   test('root / redirects to preferred locale: after switching to Russian, visiting / shows Russian', async ({
@@ -102,9 +92,9 @@ test.describe('Game Client i18n', () => {
     await page.goto('/en/settings');
     await expect(page.locator('html')).toHaveAttribute('lang', 'en');
 
-    await page.getByRole('button', { name: EN_SWITCH_TO_RU_LABEL }).click();
+    await page.getByRole('radio', { name: EN_SWITCH_TO_RU_LABEL }).click();
     await expect(page).toHaveURL(/\/ru\/settings\/?$/);
-    await expect(page.getByText(RU_CURRENT_LANGUAGE)).toBeVisible();
+    await expect(page.getByRole('radio', { name: EN_SWITCH_TO_RU_LABEL })).toBeChecked();
 
     await page.goto('/');
     await expect(page).toHaveURL(/\/ru\/explore\/alphabet\/?$/, { timeout: 10000 });


### PR DESCRIPTION
Description:
<!-- 
Thank you for contributing to Kartuli!
Please fill out this template to help reviewers understand your changes.

IMPORTANT: Ensure your PR title follows conventional commit format:
Examples:
  - feat(game-client): add user authentication
  - fix(ui): resolve button alignment issue
  - docs: update contributing guidelines
  - chore(e2e): upgrade testing dependencies
-->

## Description

Refactors the settings page to use existing panel layout components and a new styled `RadioButton` input instead of plain border buttons.

- **Settings UI:** Wraps language preferences in `Panel`, `PanelHeader`, and `PanelSection`. Header uses a new `app_settings` context string (en/ru).
- **Language selection:** Shows all supported locales as a radio group with the current locale checked; skips navigation when the selected locale is already active.
- **New component:** `RadioButton` in `ui/components/inputs/` — custom-styled native radio with design tokens and focus ring.

## Linked Issues

Closes #

---

## Type

- [x] `feat` - New feature
- [ ] `chore` - Infrastructure, setup tasks, non-feature work
- [ ] `fix` - Bug fix
- [ ] `docs` - Documentation changes
- [ ] `test` - Testing-related changes

---

## Scope

- [x] `game-client` - Game client application
- [ ] `backoffice-client` - Backoffice client application
- [ ] `ui` - UI package
- [ ] `storybook` - Storybook tool
- [ ] `e2e` - E2E testing
- [ ] `global` - Shared packages or general repository tasks

---

## Screenshots (Optional)

<!-- Add screenshots of the settings page with the new panel and radio layout -->

---

## Preview Links (Optional)



---

## Testing Notes

- [ ] Tests pass locally
- [ ] Linting passes

- Open `/en/settings` and `/ru/settings`; confirm panel header shows “App Settings” / “Настройки приложения” and language section title.
- Verify both locales appear as radios; current locale is selected.
- Switch language via radio; URL and UI locale update; cookie `preferred-locale` is set.
- Re-select the current locale; no redundant navigation.
- Keyboard: tab to radios, focus ring visible; Space/click changes selection.

---

## Documentation Changes (if applicable)

- [ ] Added or updated documentation files
- [ ] Updated cross-references in other docs (if files were renamed/moved)
- [ ] Verified all internal links still work
- [x] N/A - No documentation changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Language selection interface redesigned with radio buttons replacing previous button-based options
  * Added "App Settings" section heading to settings page
  * Updated settings layout with improved panel-based design

* **Tests**
  * End-to-end tests updated to verify radio button language selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->