### PR TITLE
chore(renovate): replace biome preset with jsonata manager and tighten grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":dependencyDashboard", "customManagers:biomeVersions"],
+  "extends": ["config:recommended", ":dependencyDashboard"],
+  "customManagers": [
+    {
+      "customType": "jsonata",
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "@biomejs/biome",
+      "fileFormat": "json",
+      "managerFilePatterns": ["/(^|/)biome(?:\\.root)?\\.(json|jsonc)$/"],
+      "matchStrings": ["{\"currentValue\": $split($.\"$schema\",(\"/\"))[-2]}"]
+    }
+  ],
   "enabledManagers": ["npm", "custom.regex"],
   "ignorePaths": [".nvmrc"],
   "schedule": ["before 3am on Monday"],
@@ -14,7 +24,7 @@
   "semanticCommits": "enabled",
   "semanticCommitType": "chore",
   "commitMessageAction": "update dependencies",
-  "commitMessageTopic": "({{{depNames}}})",
+  "commitMessageTopic": "{{depName}}",
   "automerge": false,
   "separateMajorMinor": false,
   "separateMinorPatch": false,
@@ -23,11 +33,13 @@
     {
       "matchUpdateTypes": ["security"],
       "groupName": "security updates",
+      "groupSingleUpdates": false,
       "schedule": ["at any time"]
     },
     {
       "matchUpdateTypes": ["major", "minor", "patch"],
-      "groupName": "all dependencies"
+      "groupName": "all dependencies",
+      "groupSingleUpdates": false
     },
     {
       "matchDepTypes": ["engines"],


### PR DESCRIPTION
Description:
<!-- 
Thank you for contributing to Kartuli!
Please fill out this template to help reviewers understand your changes.

IMPORTANT: Ensure your PR title follows conventional commit format:
Examples:
  - feat(game-client): add user authentication
  - fix(ui): resolve button alignment issue
  - docs: update contributing guidelines
  - chore(e2e): upgrade testing dependencies
-->

## Description

Updates Renovate configuration for Biome version tracking and dependency grouping behavior.

- Replaces the `customManagers:biomeVersions` preset with an inline JSONata custom manager that reads the Biome version from `biome.json` / `biome.root.json` schema URLs and tracks `@biomejs/biome` on npm.
- Simplifies commit message topics from `({{{depNames}}})` to `{{depName}}` for clearer per-dependency commit subjects.
- Sets `groupSingleUpdates: false` on the security and all-dependencies package rules so single updates are not forced into those groups.

---

## Linked Issues

Closes #

---

## Type

- [ ] `feat` - New feature
- [x] `chore` - Infrastructure, setup tasks, non-feature work
- [ ] `fix` - Bug fix
- [ ] `docs` - Documentation changes
- [ ] `test` - Testing-related changes

---

## Scope

- [ ] `game-client` - Game client application
- [ ] `backoffice-client` - Backoffice client application
- [ ] `ui` - UI package
- [ ] `storybook` - Storybook tool
- [ ] `e2e` - E2E testing
- [x] `global` - Shared packages or general repository tasks

---

## Screenshots (Optional)



---

## Preview Links (Optional)



---

## Testing Notes

- [x] Tests pass locally
- [x] Linting passes

Config-only change; no runtime behavior to verify beyond Renovate picking up the updated rules on the next run.

---

## Documentation Changes (if applicable)

- [ ] Added or updated documentation files
- [ ] Updated cross-references in other docs (if files were renamed/moved)
- [ ] Verified all internal links still work
- [x] N/A - No documentation changes